### PR TITLE
Enable horizontal views

### DIFF
--- a/Examples/reprocessSessions.py
+++ b/Examples/reprocessSessions.py
@@ -108,5 +108,3 @@ deleteLocalFolder = False
 batchReprocess(session_ids,calib_id,static_id,dynamic_ids,
                resolutionPoseDetection=resolutionPoseDetection,
                deleteLocalFolder=deleteLocalFolder)
-
-test = 1

--- a/Examples/reprocessSessions.py
+++ b/Examples/reprocessSessions.py
@@ -56,7 +56,6 @@ API_TOKEN = getToken()
 # or more session identifiers. The identifier is found as the 36-character string at the
 # end of the session url: app.opencap.ai/session/<session_id>
 session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
-session_ids = ['777fc756-e12a-4e15-a863-f9e7900d2045']
 
 
 # Select which trials to reprocess. You can reprocess all trials in the session 
@@ -68,8 +67,8 @@ session_ids = ['777fc756-e12a-4e15-a863-f9e7900d2045']
 # select specific reprocessed. Only one trial (str) is allowed for calib_id and
 # static_id. A list of strings is allowed for dynamic_ids.
 
-calib_id = None # None (auto-selected trial), [] (skip), or string of specific trial_id
-static_id = None # None (auto-selected trial), [] (skip), or string of specific trial_id
+calib_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
+static_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
 dynamic_ids = None # None (all dynamic trials), [] (skip), or list of trial_id strings
 
 

--- a/Examples/reprocessSessions.py
+++ b/Examples/reprocessSessions.py
@@ -56,6 +56,7 @@ API_TOKEN = getToken()
 # or more session identifiers. The identifier is found as the 36-character string at the
 # end of the session url: app.opencap.ai/session/<session_id>
 session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
+session_ids = ['777fc756-e12a-4e15-a863-f9e7900d2045']
 
 
 # Select which trials to reprocess. You can reprocess all trials in the session 
@@ -67,8 +68,8 @@ session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
 # select specific reprocessed. Only one trial (str) is allowed for calib_id and
 # static_id. A list of strings is allowed for dynamic_ids.
 
-calib_id = []  # None (auto-selected trial), [] (skip), or string of specific trial_id
-static_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
+calib_id = None # None (auto-selected trial), [] (skip), or string of specific trial_id
+static_id = None # None (auto-selected trial), [] (skip), or string of specific trial_id
 dynamic_ids = None # None (all dynamic trials), [] (skip), or list of trial_id strings
 
 
@@ -108,3 +109,5 @@ deleteLocalFolder = False
 batchReprocess(session_ids,calib_id,static_id,dynamic_ids,
                resolutionPoseDetection=resolutionPoseDetection,
                deleteLocalFolder=deleteLocalFolder)
+
+test = 1

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from utilsChecker import synchronizeVideos
 from utilsChecker import triangulateMultiviewVideo
 from utilsChecker import writeTRCfrom3DKeypoints
 from utilsChecker import popNeutralPoseImages
+from utilsChecker import rotateIntrinsics
 from utilsDetector  import runPoseDetector
 from utilsAugmenter import augmentTRC
 from utilsOpenSim import runScaleTool, getScaleTimeRange, runIKTool, generateVisualizerJson
@@ -142,7 +143,8 @@ def main(sessionName, trialName, trial_id, camerasToUse=['all'],
                         os.path.join(permIntrinsicDir,
                                       'cameraIntrinsics.pickle'))                    
                 # Intrinsics do not exist throw an error. Eventually the
-                # webapp will give you the opportunity to compute them.          
+                # webapp will give you the opportunity to compute them.
+                
                 else:
                     exception = "Intrinsics don't exist for your camera model. OpenCap supports all iOS devices released in 2018 or later: https://www.opencap.ai/get-started."
                     raise Exception(exception, exception)
@@ -156,6 +158,10 @@ def main(sessionName, trialName, trial_id, camerasToUse=['all'],
                     camName in alternateExtrinsics)
                 extrinsicPath = os.path.join(camDir, 'InputMedia', trialName, 
                                              trial_id + '.mov') 
+                                              
+                # Modify intrinsics if camera view is rotated
+                CamParams = rotateIntrinsics(CamParams,extrinsicPath)
+                
                 # for 720p, imageUpsampleFactor=4 is best for small board
                 try:
                     CamParams = calcExtrinsicsFromVideo(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ protobuf==3.19.5
 sklearn
 pingouin==0.5.2
 openpyxl
+ffmpeg-python

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -325,7 +325,7 @@ def rotateIntrinsics(CamParams,videoPath):
             # Change principle point - from upper left
             CamParams['intrinsicMat'][0,2] = ly-py
             CamParams['intrinsicMat'][1,2] = px
-        elif rotation == 279: # upside down
+        elif rotation == 270: # upside down
             # Change principle point - from upper left
             CamParams['intrinsicMat'][0,2] = lx-px
             CamParams['intrinsicMat'][1,2] = ly-py

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -11,6 +11,7 @@ import urllib.request
 import shutil
 import utilsDataman
 import requests
+import ffmpeg
 import matplotlib.pyplot as plt
 from scipy.ndimage import gaussian_filter1d
 from scipy.signal import gaussian, sosfiltfilt, butter, find_peaks
@@ -280,7 +281,59 @@ def saveCameraParameters(filename,CameraParams):
     open_file.close()
     
     return True
+
+#%% 
+def getVideoRotation(videoPath):
     
+    meta = ffmpeg.probe(videoPath)
+    try:
+        rotation = meta['format']['tags']['com.apple.quicktime.video-orientation']
+    except:
+        rotation = 90 # upright is 90, and intrinsics were captured in that orientation
+        
+    return int(rotation)
+
+#%% 
+def rotateIntrinsics(CamParams,videoPath):
+    rotation = getVideoRotation(videoPath)
+    
+    # upright is 90, which is how intrinsics recorded so no rotation needed
+    if rotation !=90:
+        originalCamParams = copy.deepcopy(CamParams)
+        fx = originalCamParams['intrinsicMat'][0,0]
+        fy = originalCamParams['intrinsicMat'][1,1]
+        px = originalCamParams['intrinsicMat'][0,2]
+        py = originalCamParams['intrinsicMat'][1,2]
+        lx = originalCamParams['imageSize'][1]
+        ly = originalCamParams['imageSize'][0]
+        
+        old = copy.copy(CamParams)
+    
+        if rotation == 0: # leaning left
+            # Flip image size
+            CamParams['imageSize'] = np.flipud(CamParams['imageSize'])
+            # Flip focal lengths
+            CamParams['intrinsicMat'][0,0] = fy
+            CamParams['intrinsicMat'][1,1] = fx
+            # Change principle point - from upper left
+            CamParams['intrinsicMat'][0,2] = py
+            CamParams['intrinsicMat'][1,2] = lx-px   
+        elif rotation == 180: # leaning right
+            # Flip image size
+            CamParams['imageSize'] = np.flipud(CamParams['imageSize'])
+            # Flip focal lengths
+            CamParams['intrinsicMat'][0,0] = fy
+            CamParams['intrinsicMat'][1,1] = fx
+            # Change principle point - from upper left
+            CamParams['intrinsicMat'][0,2] = ly-py
+            CamParams['intrinsicMat'][1,2] = px
+        elif rotation == 279: # upside down
+            # Change principle point - from upper left
+            CamParams['intrinsicMat'][0,2] = lx-px
+            CamParams['intrinsicMat'][1,2] = ly-py
+            
+    return CamParams
+
 # %% 
 def calcExtrinsics(imageFileName, CameraParams, CheckerBoardParams,
                    imageScaleFactor=1,visualize=False,

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -306,9 +306,7 @@ def rotateIntrinsics(CamParams,videoPath):
         py = originalCamParams['intrinsicMat'][1,2]
         lx = originalCamParams['imageSize'][1]
         ly = originalCamParams['imageSize'][0]
-        
-        old = copy.copy(CamParams)
-    
+           
         if rotation == 0: # leaning left
             # Flip image size
             CamParams['imageSize'] = np.flipud(CamParams['imageSize'])


### PR DESCRIPTION
We only needed to rotate the intrinsics. By re-writing the videos, they get automatically rotated, which is nice.

I tested:
- one vertical, one horizontal
- one leaning left, one leaning right
- TODO one upside down, one leaning left
- running the currently released ios app

The iphone portrait lock issue is non-intuitive. Posted issue to ios repo.

I think we can push this to the backend servers whenever. Let's see if we can get the error message on ios before pushing ios update.