### PR TITLE
Increase threshold time out

### DIFF
--- a/utilsDetector.py
+++ b/utilsDetector.py
@@ -201,7 +201,7 @@ def runOpenPoseCMD(pathOpenPose, resolutionPoseDetection, cameraDirectory,
                 if not os.path.isfile(vid_path):
                     break
                 
-                if start + 60*5 < time.time():
+                if start + 60*30 < time.time():
                     raise Exception("OpenPose processing timeout")
                 
                 time.sleep(0.1)
@@ -309,7 +309,7 @@ def runMMposeVideo(
                     if not os.path.isfile(vid_path):
                         break
                     
-                    if start + 60*5 < time.time():
+                    if start + 60*30 < time.time():
                         raise Exception("mmpose processing timeout")
                     
                     time.sleep(0.1)


### PR DESCRIPTION
On long trials (eg, 1min), HRNet needs more than 5min (current timeout threshold). This was causing the bugs some users experienced. I don't think there is a real reason for this timeout threshold so I would bump it up to 30min.

Addresses #5 