### PR TITLE
fix sync bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ Examples/Data/*
 
 *.ini
 *.stats
+
+tests/

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -1064,7 +1064,7 @@ def synchronizeVideoKeypoints(keypointList, confidenceList,
                                  'confidence': confidenceSyncListFilt,
                                  'cameras2Use': c_cameras2Use
                                  }
-                corVal,lag = cross_corr(vertVel,vertVelList[0],multCorrGaussianStd=20,visualize=False,dataForReproj=dataForReproj) # gaussian curve gets multipled by correlation plot - helping choose the smallest shift value for periodic motions
+                corVal,lag = cross_corr(vertVel,vertVelList[0],multCorrGaussianStd=maxShiftSteps/2,visualize=False,dataForReproj=dataForReproj) # gaussian curve gets multipled by correlation plot - helping choose the smallest shift value for periodic motions
             elif syncActivity == 'gait':
                 
                 dataForReproj = {'CamParamList':c_CameraParams,
@@ -2042,6 +2042,12 @@ def cross_corr(y1, y2,multCorrGaussianStd=None,visualize=False, dataForReproj=No
     # find correlation peak with minimum reprojection error
     if dataForReproj is not None:
         _,peaks = find_peaks(corr, height=.1)
+        
+        # inject no delay so it doesn't thrown an error for static trials
+        if len(peaks['peak_heights']) == 0:
+            peaks['peak_heights'] = np.ndarray((1,1))
+            peaks['peak_heights'][0] = corr[int(len(corr)/2)]
+            print('There were no peaks in the vert vel cross correlation. Using 0 lag.')
         idxPeaks = np.squeeze(np.asarray([np.argwhere(peaks['peak_heights'][i]==corr) for i in range(len(peaks['peak_heights']))]))
         lags = idxPeaks-shift
         # look at 3 lags closest to 0

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -2043,7 +2043,7 @@ def cross_corr(y1, y2,multCorrGaussianStd=None,visualize=False, dataForReproj=No
     if dataForReproj is not None:
         _,peaks = find_peaks(corr, height=.1)
         
-        # inject no delay so it doesn't thrown an error for static trials
+        # inject no delay so it doesn't throw an error for static trials
         if len(peaks['peak_heights']) == 0:
             peaks['peak_heights'] = np.ndarray((1,1))
             peaks['peak_heights'][0] = corr[int(len(corr)/2)]


### PR DESCRIPTION
- gaussian width for cross correlation was hardcoded. now dependent on framerate.
- added failsafe if findpeaks fails on cross corr (which it often does for neutral trials). Defaults to 0 lag.

Tests I've done:
-> this fixed several of the issues with recent outdoor data collections (probably greater lags due to slower wifi)
-> reprocessed and visualized benchmarks, and all worked.