### PR TITLE
fix mmpose - nobody detected

### DIFF
--- a/mmpose/loop_mmpose.py
+++ b/mmpose/loop_mmpose.py
@@ -58,3 +58,4 @@ while True:
         
     except:
         logging.info("Pose detection failed.")
+        os.remove(video_path)


### PR DESCRIPTION
@suhlrich here is a fix for the weird mmpose bug I could not reproduce! There was an infinite loop when pose detection failed with mmpose, which happens for instance when nobody is detected in the scene. Reason is that mmpose actually throws an error, so the exception was caught but the video was still there so it would keep on trying over and over again until I stopped the docker. i just added removing the video in case it fails, which works fine.

