### PR TITLE
Specify worker type

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ API_URL = getAPIURL()
 workerType = getWorkerType()
 
 # if true, will delete entire data directory when finished with a trial
-isDocker = False
+isDocker = True
 
 while True:
     # workerType = 'calibration' -> just processes calibration and neutral

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ while True:
         continue
 
     if r.status_code == 404:
-        logging.info("... pulling " + workerType + " trials ...")
+        logging.info("...workerType: " + workerType + " ...")
         time.sleep(1)
         continue
     

--- a/app.py
+++ b/app.py
@@ -35,8 +35,8 @@ while True:
         continue
 
     if r.status_code == 404:
-        logging.info(".")
-        time.sleep(0.5)
+        logging.info("... pulling " + workerType + " trials ...")
+        time.sleep(1)
         continue
     
     if np.floor(r.status_code/100) == 5: # 5xx codes are server faults

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ import traceback
 import logging
 import glob
 import numpy as np
-from utilsAPI import getAPIURL
+from utilsAPI import getAPIURL, getWorkerType
 from utilsAuth import getToken
 from utils import getDataDirectory
 
@@ -16,12 +16,16 @@ logging.basicConfig(level=logging.INFO)
 
 API_TOKEN = getToken()
 API_URL = getAPIURL()
+workerType = getWorkerType()
 
 # if true, will delete entire data directory when finished with a trial
-isDocker = True
+isDocker = False
 
 while True:
-    queue_path = "trials/dequeue/"
+    # workerType = 'calibration' -> just processes calibration and neutral
+    # workerType = 'all' -> processes all types of trials
+    # no query string -> defaults to 'all'
+    queue_path = "trials/dequeue/?workerType=" + workerType
     try:
         r = requests.get("{}{}".format(API_URL, queue_path),
                          headers = {"Authorization": "Token {}".format(API_TOKEN)})

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ while True:
         continue
 
     if r.status_code == 404:
-        logging.info("...workerType: " + workerType + " ...")
+        logging.info("...pulling " + workerType + " trials.")
         time.sleep(1)
         continue
     

--- a/utilsAPI.py
+++ b/utilsAPI.py
@@ -18,3 +18,11 @@ def getAPIURL():
         API_URL= API_URL + '/'
 
     return API_URL
+
+def getWorkerType():
+    try: # look in environment file
+        workerType = config("WORKER_TYPE")
+    except: # default
+        workerType = "all"
+    
+    return workerType


### PR DESCRIPTION
We can now specify `WORKER_TYPE` in the .env file to determine what trials a machine pulls.

"calibration" -> just calib and neutral
"all" ->pull all trials, prioritizing calib and neutral like it was before

If we do not specify this in the .env file, we default to "all," just like before.

I tested this locally on a synthesized data collection and it worked. I did not test with docker yet, so we should probably test there first with the different settings

Should be merged after https://github.com/stanfordnmbl/opencap-api/pull/24