### PR TITLE
Support for reprocessing trials with missing videos

### DIFF
--- a/Examples/changeSessionMetadata.py
+++ b/Examples/changeSessionMetadata.py
@@ -46,16 +46,15 @@ sys.path.append(os.path.abspath('./..'))
 
 from utils import changeSessionMetadata
 
-session_ids = ["6dc0721a-7457-4ce1-8523-577900b5399f"]
+session_ids = ["0d46adef-62cb-455f-9ff3-8116717cc2fe"]
 
 # Dictionary of metadata fields to change (see sessionMetadata.yaml).
 newMetadata = {
-    'camerastouse': ['all_available']
-    # 'openSimModel':'LaiUhlrich2022_shoulder',
-    # 'posemodel':'hrnet',
-    # 'augmentermodel':'v0.3',
-    # 'filterfrequency':15,
-    # 'datasharing':'Share processed data and identified videos',
-    # 'scalingsetup': 'upright_standing_pose'
+    'openSimModel':'LaiUhlrich2022_shoulder',
+    'posemodel':'hrnet',
+    'augmentermodel':'v0.3',
+    'filterfrequency':15,
+    'datasharing':'Share processed data and identified videos',
+    'scalingsetup': 'upright_standing_pose'
 }
 changeSessionMetadata(session_ids,newMetadata)

--- a/Examples/changeSessionMetadata.py
+++ b/Examples/changeSessionMetadata.py
@@ -46,15 +46,16 @@ sys.path.append(os.path.abspath('./..'))
 
 from utils import changeSessionMetadata
 
-session_ids = ["0d46adef-62cb-455f-9ff3-8116717cc2fe"]
+session_ids = ["6dc0721a-7457-4ce1-8523-577900b5399f"]
 
 # Dictionary of metadata fields to change (see sessionMetadata.yaml).
 newMetadata = {
-    'openSimModel':'LaiUhlrich2022_shoulder',
-    'posemodel':'hrnet',
-    'augmentermodel':'v0.3',
-    'filterfrequency':15,
-    'datasharing':'Share processed data and identified videos',
-    'scalingsetup': 'upright_standing_pose'
+    'camerastouse': ['all_available']
+    # 'openSimModel':'LaiUhlrich2022_shoulder',
+    # 'posemodel':'hrnet',
+    # 'augmentermodel':'v0.3',
+    # 'filterfrequency':15,
+    # 'datasharing':'Share processed data and identified videos',
+    # 'scalingsetup': 'upright_standing_pose'
 }
 changeSessionMetadata(session_ids,newMetadata)

--- a/Examples/reprocessSessions.py
+++ b/Examples/reprocessSessions.py
@@ -55,7 +55,7 @@ API_TOKEN = getToken()
 # Enter the identifier(s) of the session(s) you want to reprocess. This is a list of one
 # or more session identifiers. The identifier is found as the 36-character string at the
 # end of the session url: app.opencap.ai/session/<session_id>
-session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
+session_ids = ['6dc0721a-7457-4ce1-8523-577900b5399f']
 
 # Select which trials to reprocess. You can reprocess all trials in the session 
 # by entering None in all fields below. The correct calibration and static
@@ -68,7 +68,7 @@ session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
 
 calib_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
 static_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
-dynamic_trialNames = None # None (all dynamic trials), [] (skip), or list of trial names
+dynamic_trialNames = ['test_2'] # None (all dynamic trials), [] (skip), or list of trial names
 
 # Select which pose estimation model to use; options are 'OpenPose' and 'hrnet'.
 # If the same pose estimation model was used when collecting data with the web
@@ -79,7 +79,7 @@ dynamic_trialNames = None # None (all dynamic trials), [] (skip), or list of tri
 # selected 'hrnet' when collecting data with the web app. You can however re-
 # process data originally collected with 'hrnet' with 'OpenPose' if you have 
 # installed OpenPose locally (see README.md for instructions).
-poseDetector = 'OpenPose'
+poseDetector = 'hrnet'
 
 # OpenPose only:
 # Select the resolution at which the videos are processed. There are no
@@ -110,4 +110,5 @@ deleteLocalFolder = False
 batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,
                poseDetector=poseDetector,
                resolutionPoseDetection=resolutionPoseDetection,
-               deleteLocalFolder=deleteLocalFolder)
+               deleteLocalFolder=deleteLocalFolder,
+               cameras_to_use = ['all_available'])

--- a/Examples/reprocessSessions.py
+++ b/Examples/reprocessSessions.py
@@ -55,7 +55,7 @@ API_TOKEN = getToken()
 # Enter the identifier(s) of the session(s) you want to reprocess. This is a list of one
 # or more session identifiers. The identifier is found as the 36-character string at the
 # end of the session url: app.opencap.ai/session/<session_id>
-session_ids = ['6dc0721a-7457-4ce1-8523-577900b5399f']
+session_ids = ['23d52d41-69fe-47cf-8b60-838e4268dd50']
 
 # Select which trials to reprocess. You can reprocess all trials in the session 
 # by entering None in all fields below. The correct calibration and static
@@ -68,7 +68,7 @@ session_ids = ['6dc0721a-7457-4ce1-8523-577900b5399f']
 
 calib_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
 static_id = [] # None (auto-selected trial), [] (skip), or string of specific trial_id
-dynamic_trialNames = ['test_2'] # None (all dynamic trials), [] (skip), or list of trial names
+dynamic_trialNames = None # None (all dynamic trials), [] (skip), or list of trial names
 
 # Select which pose estimation model to use; options are 'OpenPose' and 'hrnet'.
 # If the same pose estimation model was used when collecting data with the web
@@ -79,7 +79,7 @@ dynamic_trialNames = ['test_2'] # None (all dynamic trials), [] (skip), or list 
 # selected 'hrnet' when collecting data with the web app. You can however re-
 # process data originally collected with 'hrnet' with 'OpenPose' if you have 
 # installed OpenPose locally (see README.md for instructions).
-poseDetector = 'hrnet'
+poseDetector = 'OpenPose'
 
 # OpenPose only:
 # Select the resolution at which the videos are processed. There are no
@@ -110,5 +110,4 @@ deleteLocalFolder = False
 batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,
                poseDetector=poseDetector,
                resolutionPoseDetection=resolutionPoseDetection,
-               deleteLocalFolder=deleteLocalFolder,
-               cameras_to_use = ['all_available'])
+               deleteLocalFolder=deleteLocalFolder)

--- a/app.py
+++ b/app.py
@@ -122,12 +122,14 @@ while True:
         continue
 
     # This is a hack to have the trials with status "reprocess" to be reprocessed
-    # with camerasToUse_c = ['all_available'] instead of ['all']. In practice, this
+    # with camerasToUse = ['all_available'] instead of ['all']. In practice, this
     # allows reprocessing on server trials that failed because video(s) were not available.
     # This is a temporary solution until we have a better way to handle this. By default,
     # trials with missing videos are error-ed out directly so that we do not spend time
-    # on processing them.
+    # on processing them. Problem is that these trials then don't have pose pickles, which
+    # makes is hard for local reprocessing (hrnet still a hassle to install locally on Windows).
     status = trial["status"]
+    logging.info(f"Trial status: {status}")
     if status == "reprocess":
         camerasToUse_c = ['all_available']
     else:

--- a/app.py
+++ b/app.py
@@ -129,16 +129,16 @@ while True:
     # on processing them. Problem is that these trials then don't have pose pickles, which
     # makes is hard for local reprocessing (hrnet still a hassle to install locally on Windows).
     # status = trial["status"]
-    status = 'reprocess'
-    logging.info(f"Trial status: {status}")
-    if status == "reprocess":
-        camerasToUse_c = ['all_available']
-    else:
-        camerasToUse_c = ['all']
-        if any([v["video"] is None for v in trial["videos"]]):
-            r = requests.patch(trial_url, data={"status": "error"},
-                        headers = {"Authorization": "Token {}".format(API_TOKEN)})
-            continue
+    # status = 'reprocess'
+    # logging.info(f"Trial status: {status}")
+    # if status == "reprocess":
+    #     camerasToUse_c = ['all_available']
+    # else:
+    #     camerasToUse_c = ['all']
+    #     if any([v["video"] is None for v in trial["videos"]]):
+    #         r = requests.patch(trial_url, data={"status": "error"},
+    #                     headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    #         continue
 
     trial_type = "dynamic"
     if trial["name"] == "calibration":
@@ -151,7 +151,7 @@ while True:
 
     try:
         # trigger reset of timer for last processed trial                            
-        processTrial(trial["session"], trial["id"], trial_type=trial_type, isDocker=isDocker, camerasToUse=camerasToUse_c)   
+        processTrial(trial["session"], trial["id"], trial_type=trial_type, isDocker=isDocker)   
         # note a result needs to be posted for the API to know we finished, but we are posting them 
         # automatically thru procesTrial now
         r = requests.patch(trial_url, data={"status": "done"},

--- a/app.py
+++ b/app.py
@@ -121,24 +121,11 @@ while True:
                          headers = {"Authorization": "Token {}".format(API_TOKEN)})
         continue
 
-    # This is a hack to have the trials with status "reprocess" to be reprocessed
-    # with camerasToUse = ['all_available'] instead of ['all']. In practice, this
-    # allows reprocessing on server trials that failed because video(s) were not available.
-    # This is a temporary solution until we have a better way to handle this. By default,
-    # trials with missing videos are error-ed out directly so that we do not spend time
-    # on processing them. Problem is that these trials then don't have pose pickles, which
-    # makes is hard for local reprocessing (hrnet still a hassle to install locally on Windows).
-    # status = trial["status"]
-    # status = 'reprocess'
-    # logging.info(f"Trial status: {status}")
-    # if status == "reprocess":
-    #     camerasToUse_c = ['all_available']
-    # else:
-    #     camerasToUse_c = ['all']
-    #     if any([v["video"] is None for v in trial["videos"]]):
-    #         r = requests.patch(trial_url, data={"status": "error"},
-    #                     headers = {"Authorization": "Token {}".format(API_TOKEN)})
-    #         continue
+    # The following is now done in main, to allow reprocessing trials with missing videos
+    # if any([v["video"] is None for v in trial["videos"]]):
+    #     r = requests.patch(trial_url, data={"status": "error"},
+    #                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    #     continue
 
     trial_type = "dynamic"
     if trial["name"] == "calibration":

--- a/app.py
+++ b/app.py
@@ -128,7 +128,8 @@ while True:
     # trials with missing videos are error-ed out directly so that we do not spend time
     # on processing them. Problem is that these trials then don't have pose pickles, which
     # makes is hard for local reprocessing (hrnet still a hassle to install locally on Windows).
-    status = trial["status"]
+    # status = trial["status"]
+    status = 'reprocess'
     logging.info(f"Trial status: {status}")
     if status == "reprocess":
         camerasToUse_c = ['all_available']

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import traceback
 
 import logging
 logging.basicConfig(level=logging.INFO)
+import time
 
 from utils import importMetadata, loadCameraParameters, getVideoExtension
 from utils import getDataDirectory, getOpenPoseDirectory, getMMposeDirectory
@@ -43,6 +44,9 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
          filter_frequency='default', overwriteFilterFrequency=False,
          scaling_setup='upright_standing_pose', overwriteScalingSetup=False,
          overwriteCamerasToUse=False):
+    
+    # Start time.
+    start_time = time.time()
 
     # %% High-level settings.
     # Camera calibration.
@@ -302,6 +306,9 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
     # Trial relative path
     trialRelativePath = os.path.join('InputMedia', trialName, trial_id)
     
+    # Time.
+    time_before_pose_detection = time.time()
+    logging.info('Before pose detection elapsed time: {}'.format(time_before_pose_detection - start_time))
     if runPoseDetection:
         # Detect if checkerboard is upside down.
         upsideDownChecker = isCheckerboardUpsideDown(CamParamDict)
@@ -389,7 +396,9 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
                     Visit https://www.opencap.ai/best-pratices to learn more about data collection
                     and https://www.opencap.ai/troubleshooting for potential causes for a failed trial."""
                 raise Exception(exception, traceback.format_exc())
-        
+
+    time_before_synchronization = time.time()
+    logging.info('Pose estimation elapsed time: {}'.format(time_before_synchronization - time_before_pose_detection))    
     if runSynchronization:
         # Synchronize videos.
         try:
@@ -424,7 +433,9 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
     if scaleModel and calibrationOptions is not None and alternateExtrinsics is None:
         # Automatically select the camera calibration to use
         CamParamDict = autoSelectExtrinsicSolution(sessionDir,keypoints2D,confidence,calibrationOptions)
-         
+
+    time_before_triangulation = time.time()
+    logging.info('Synchronization elapsed time: {}'.format(time_before_triangulation - time_before_synchronization))      
     if runTriangulation:
         # Triangulate.
         try:
@@ -471,6 +482,8 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             pathAugmentedOutputFiles[trialName] = os.path.join(
                     postAugmentationDir, trial_id + "_" + augmenterModelName +".trc")
     
+    time_before_augmentation = time.time()
+    logging.info('Triangulation elapsed time: {}'.format(time_before_augmentation - time_before_triangulation))  
     if runMarkerAugmentation:
         os.makedirs(postAugmentationDir, exist_ok=True)    
         augmenterDir = os.path.join(baseDir, "MarkerAugmenter")
@@ -494,6 +507,8 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             vertical_offset = 0.01   
         
     # %% OpenSim pipeline.
+    time_before_opensim = time.time()
+    logging.info('Augmentation elapsed time: {}'.format(time_before_opensim - time_before_augmentation))  
     if runOpenSimPipeline:
         openSimPipelineDir = os.path.join(baseDir, "opensimPipeline")        
         
@@ -618,3 +633,8 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             settings['verticalOffset'] = vertical_offset_settings 
         with open(pathSettings, 'w') as file:
             yaml.dump(settings, file)
+
+    # End time.
+    end_time = time.time()
+    logging.info('OpenSim elapsed time: {}'.format(end_time - time_before_opensim))  
+    logging.info('Total elapsed time: {}'.format(end_time - start_time))

--- a/main.py
+++ b/main.py
@@ -121,6 +121,12 @@ def main(sessionName, trialName, trial_id, camerasToUse=['all'],
     else:
         scalingSetup = scaling_setup
 
+    # If reprocess is in sessionMetadata, reprocess with all cameras available
+    # instead of all cameras. This allows reprocessing of trials with missing
+    # videos.
+    if 'reprocess' in sessionMetadata:
+        camerasToUse = ['all_available']
+
     # %% Paths to pose detector folder for local testing.
     if poseDetector == 'OpenPose':
         poseDetectorDirectory = getOpenPoseDirectory(isDocker)

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ from utilsDetector  import runPoseDetector
 from utilsAugmenter import augmentTRC
 from utilsOpenSim import runScaleTool, getScaleTimeRange, runIKTool, generateVisualizerJson
 
-def main(sessionName, trialName, trial_id, camerasToUse=['all'],
+def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
          intrinsicsFinalFolder='Deployed', isDocker=False,
          extrinsicsTrial=False, alternateExtrinsics=None, 
          calibrationOptions=None,
@@ -41,7 +41,8 @@ def main(sessionName, trialName, trial_id, camerasToUse=['all'],
          genericFolderNames=False, offset=True, benchmark=False,
          dataDir=None, overwriteAugmenterModel=False,
          filter_frequency='default', overwriteFilterFrequency=False,
-         scaling_setup='upright_standing_pose', overwriteScalingSetup=False):
+         scaling_setup='upright_standing_pose', overwriteScalingSetup=False,
+         overwriteCamerasToUse=False):
 
     # %% High-level settings.
     # Camera calibration.
@@ -121,11 +122,14 @@ def main(sessionName, trialName, trial_id, camerasToUse=['all'],
     else:
         scalingSetup = scaling_setup
 
-    # If reprocess is in sessionMetadata, reprocess with all cameras available
-    # instead of all cameras. This allows reprocessing of trials with missing
-    # videos.
-    if 'reprocess' in sessionMetadata:
-        camerasToUse = ['all_available']
+    # If camerastouse is in sessionMetadata, reprocess with specified cameras.
+    # This allows reprocessing trials with missing videos. If
+    # overwriteCamerasToUse is True, the camera selection is the one
+    # passed as an argument to main(). This is useful for local testing.
+    if 'camerastouse' in sessionMetadata and not overwriteCamerasToUse:
+        camerasToUse = sessionMetadata['camerastouse']
+    else:
+        camerasToUse = cameras_to_use
 
     # %% Paths to pose detector folder for local testing.
     if poseDetector == 'OpenPose':

--- a/main.py
+++ b/main.py
@@ -15,7 +15,6 @@ import traceback
 
 import logging
 logging.basicConfig(level=logging.INFO)
-import time
 
 from utils import importMetadata, loadCameraParameters, getVideoExtension
 from utils import getDataDirectory, getOpenPoseDirectory, getMMposeDirectory
@@ -44,9 +43,6 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
          filter_frequency='default', overwriteFilterFrequency=False,
          scaling_setup='upright_standing_pose', overwriteScalingSetup=False,
          overwriteCamerasToUse=False):
-    
-    # Start time.
-    start_time = time.time()
 
     # %% High-level settings.
     # Camera calibration.
@@ -306,9 +302,6 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
     # Trial relative path
     trialRelativePath = os.path.join('InputMedia', trialName, trial_id)
     
-    # Time.
-    time_before_pose_detection = time.time()
-    logging.info('Before pose detection elapsed time: {}'.format(time_before_pose_detection - start_time))
     if runPoseDetection:
         # Detect if checkerboard is upside down.
         upsideDownChecker = isCheckerboardUpsideDown(CamParamDict)
@@ -396,9 +389,7 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
                     Visit https://www.opencap.ai/best-pratices to learn more about data collection
                     and https://www.opencap.ai/troubleshooting for potential causes for a failed trial."""
                 raise Exception(exception, traceback.format_exc())
-
-    time_before_synchronization = time.time()
-    logging.info('Pose estimation elapsed time: {}'.format(time_before_synchronization - time_before_pose_detection))    
+      
     if runSynchronization:
         # Synchronize videos.
         try:
@@ -433,9 +424,7 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
     if scaleModel and calibrationOptions is not None and alternateExtrinsics is None:
         # Automatically select the camera calibration to use
         CamParamDict = autoSelectExtrinsicSolution(sessionDir,keypoints2D,confidence,calibrationOptions)
-
-    time_before_triangulation = time.time()
-    logging.info('Synchronization elapsed time: {}'.format(time_before_triangulation - time_before_synchronization))      
+     
     if runTriangulation:
         # Triangulate.
         try:
@@ -482,8 +471,6 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             pathAugmentedOutputFiles[trialName] = os.path.join(
                     postAugmentationDir, trial_id + "_" + augmenterModelName +".trc")
     
-    time_before_augmentation = time.time()
-    logging.info('Triangulation elapsed time: {}'.format(time_before_augmentation - time_before_triangulation))  
     if runMarkerAugmentation:
         os.makedirs(postAugmentationDir, exist_ok=True)    
         augmenterDir = os.path.join(baseDir, "MarkerAugmenter")
@@ -507,8 +494,6 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             vertical_offset = 0.01   
         
     # %% OpenSim pipeline.
-    time_before_opensim = time.time()
-    logging.info('Augmentation elapsed time: {}'.format(time_before_opensim - time_before_augmentation))  
     if runOpenSimPipeline:
         openSimPipelineDir = os.path.join(baseDir, "opensimPipeline")        
         
@@ -633,8 +618,3 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
             settings['verticalOffset'] = vertical_offset_settings 
         with open(pathSettings, 'w') as file:
             yaml.dump(settings, file)
-
-    # End time.
-    end_time = time.time()
-    logging.info('OpenSim elapsed time: {}'.format(end_time - time_before_opensim))  
-    logging.info('Total elapsed time: {}'.format(end_time - start_time))

--- a/utils.py
+++ b/utils.py
@@ -671,7 +671,7 @@ def changeSessionMetadata(session_ids,newMetaDict):
         for newMeta in newMetaDict:
             if not newMeta in addedKey:
                 print("Could not find {} in existing metadata, trying to add it.".format(newMeta))
-                settings_fields = ['framerate', 'posemodel', 'openSimModel', 'augmentermodel', 'filterfrequency', 'scalingsetup']
+                settings_fields = ['framerate', 'posemodel', 'openSimModel', 'augmentermodel', 'filterfrequency', 'scalingsetup', 'camerastouse']
                 if newMeta in settings_fields:
                     if 'settings' not in existingMeta:
                         existingMeta['settings'] = {}

--- a/utilsServer.py
+++ b/utilsServer.py
@@ -41,7 +41,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
                  hasWritePermissions = True,
                  use_existing_pose_pickle = False,
                  batchProcess = False,
-                 camerasToUse=['all']):
+                 cameras_to_use=['all']):
 
     # Get session directory
     session_name = session_id 
@@ -63,7 +63,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
         try:
             main(session_name, trial_name, trial_id, isDocker=isDocker, extrinsicsTrial=True,
                  imageUpsampleFactor=imageUpsampleFactor,genericFolderNames = True,
-                 camerasToUse=camerasToUse)
+                 cameras_to_use=cameras_to_use)
         except Exception as e:
             error_msg = {}
             error_msg['error_msg'] = e.args[0]
@@ -125,7 +125,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
                  genericFolderNames = True,
                  bbox_thr = bbox_thr,
                  calibrationOptions = calibrationOptions,
-                 camerasToUse=camerasToUse)
+                 cameras_to_use=cameras_to_use)
         except Exception as e:       
             # Try to post pose pickles so can be used offline. This function will 
             # error at kinematics most likely, but if pose estimation completed,
@@ -215,7 +215,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
                  resolutionPoseDetection = resolutionPoseDetection,
                  genericFolderNames = True,
                  bbox_thr = bbox_thr,
-                 camerasToUse=camerasToUse)
+                 cameras_to_use=cameras_to_use)
         except Exception as e:
             # Try to post pose pickles so can be used offline. This function will 
             # error at kinematics most likely, but if pose estimation completed,
@@ -336,7 +336,7 @@ def newSessionSameSetup(session_id_old,session_id_new,extrinsicTrialName='calibr
 def batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,poseDetector='OpenPose', 
                    resolutionPoseDetection='1x736',deleteLocalFolder=True,
                    isServer=False, use_existing_pose_pickle=True,
-                   camerasToUse=['all']):
+                   cameras_to_use=['all']):
 
     # extract trial ids from trial names
     if dynamic_trialNames is not None and len(dynamic_trialNames)>0:
@@ -372,7 +372,7 @@ def batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,poseDetecto
                               deleteLocalFolder = deleteLocalFolder,
                               isDocker=isServer,
                               hasWritePermissions = hasWritePermissions,
-                              camerasToUse=camerasToUse)
+                              cameras_to_use=cameras_to_use)
                 statusData = {'status':'done'}
                 _ = requests.patch(API_URL + "trials/{}/".format(calib_id_toProcess), data=statusData,
                          headers = {"Authorization": "Token {}".format(API_TOKEN)})
@@ -399,7 +399,7 @@ def batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,poseDetecto
                               hasWritePermissions = hasWritePermissions,
                               use_existing_pose_pickle = use_existing_pose_pickle,
                               batchProcess = True,
-                              camerasToUse=camerasToUse)
+                              cameras_to_use=cameras_to_use)
                 statusData = {'status':'done'}
                 _ = requests.patch(API_URL + "trials/{}/".format(static_id_toProcess), data=statusData,
                          headers = {"Authorization": "Token {}".format(API_TOKEN)})
@@ -431,7 +431,7 @@ def batchReprocess(session_ids,calib_id,static_id,dynamic_trialNames,poseDetecto
                           hasWritePermissions = hasWritePermissions,
                           use_existing_pose_pickle = use_existing_pose_pickle,
                           batchProcess = True,
-                          camerasToUse=camerasToUse)
+                          cameras_to_use=cameras_to_use)
                 
                 statusData = {'status':'done'}
                 _ = requests.patch(API_URL + "trials/{}/".format(dID), data=statusData,


### PR DESCRIPTION
This PR adds support for reprocessing trials that do not have all videos uploaded. There are two ways this can happen: 1) the camera disconnected before hitting start recording. In that case, you have only 2 videos in db. 2) the camera disconnected while the trial was being recorded or during upload. In that case, you cancel upload (or it times out) and you have an entry in the db with video: null. In both cases, the trials are error-ed, but using different mechanisms.

In this PR, I adjusted a flag passed to main `camerastouse` that is `['all']` by default, but that can now be set to `['all_available']`. When that's the case, then a trial can be processed, even if not all videos are available. To be able to reprocess trials on server using that flag, I added the possibility to add that variable to the metadata. Also, I removed a check in app.py that was checking if all video entries actually had a video file. This is now implemented in main. This allows a trial with missing videos to "pass app.py". Note that a trial that has missing videos is not dequeued directly, but after 15 minutes, which is fine.

All is all, it should not change anything to current user experience: A trial with missing videos will be error-ed out. However, if you add the variable to the metadata and kick back the trials to the server, then they will be processed. I tested and it is working all fine. You also see in the main_settings yaml which cameras were used.