### PR TITLE
[WIP] Ignore camera confidence when syncing with hand raise

### DIFF
--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -1033,7 +1033,7 @@ def synchronizeVideoKeypoints(keypointList, confidenceList,
     # Re-sample the lists    
     vertVelList = [v[idxStart:idxEnd] for v in vertVelList]
     mkrSpeedList = [v[:,idxStart:idxEnd] for v in mkrSpeedList]
-    handPunchVertPositionList = [p[:,idxStart:idxEnd] for p in handPunchVertPositionList]
+    # handPunchVertPositionList = [p[:,idxStart:idxEnd] for p in handPunchVertPositionList]
     allMarkerList = [p[:,idxStart:idxEnd] for p in allMarkerList]
     confSyncList= [c[:,idxStart:idxEnd] for c in confidenceList]
     


### PR DESCRIPTION
I believe commenting out this line should allow hand punch synchronization to be performed without eliminating low-confidence keypoints.