### PR TITLE
automate image name across makefile and docker-compose

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,19 +1,36 @@
 BASE_NAME := 660440363484.dkr.ecr.us-west-2.amazonaws.com
 REPO_NAME := opencap
 PROD_BRANCH := main
+DEV_BRANCH := dev
 
 # Determine the branch name
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
-# Determine image tag based on branch
+# Determine image tag and name based on branch
+# If not 'main' or 'dev', then build local image
 ifeq ($(CURRENT_BRANCH),$(PROD_BRANCH))
-    OPENCAP_IMAGE_TAG := opencap
+	OPENCAP_IMAGE_TAG := opencap
 	OPENPOSE_IMAGE_TAG := openpose
 	MMPOSE_IMAGE_TAG := mmpose
-else
-    OPENCAP_IMAGE_TAG := opencap-dev
+
+	OPENCAP_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(OPENCAP_IMAGE_TAG)
+	OPENPOSE_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(OPENPOSE_IMAGE_TAG)
+	MMPOSE_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(MMPOSE_IMAGE_TAG)
+
+else ifeq ($(CURRENT_BRANCH),$(DEV_BRANCH))
+	OPENCAP_IMAGE_TAG := opencap-dev
 	OPENPOSE_IMAGE_TAG := openpose-dev
 	MMPOSE_IMAGE_TAG := mmpose-dev
+
+	OPENCAP_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(OPENCAP_IMAGE_TAG)
+	OPENPOSE_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(OPENPOSE_IMAGE_TAG)
+	MMPOSE_IMAGE_NAME := $(BASE_NAME)/$(REPO_NAME)/$(MMPOSE_IMAGE_TAG)
+
+else
+	OPENCAP_IMAGE_NAME := opencap-local
+	OPENPOSE_IMAGE_NAME := openpose-local
+	MMPOSE_IMAGE_NAME := mmpose-local
+
 endif
 
 # Get git commit hash info to pass it into container
@@ -24,19 +41,39 @@ build:
 	wget -c -O ../mmpose/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth https://mc-opencap-public.s3.us-west-2.amazonaws.com/mmpose_pth/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth
 	wget -c -O ../mmpose/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth https://mc-opencap-public.s3.us-west-2.amazonaws.com/mmpose_pth/hrnet_w48_coco_wholebody_384x288_dark-f5726563_20200918.pth
 	
-	docker build --build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) -t $(BASE_NAME)/$(REPO_NAME)/$(OPENCAP_IMAGE_TAG) .. -f Dockerfile
-	docker build -t $(BASE_NAME)/$(REPO_NAME)/$(OPENPOSE_IMAGE_TAG) .. -f openpose/Dockerfile
-	docker build -t $(BASE_NAME)/$(REPO_NAME)/$(MMPOSE_IMAGE_TAG) .. -f mmpose/Dockerfile
+	docker build --build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) -t $(OPENCAP_IMAGE_NAME) .. -f Dockerfile
+	docker build -t $(OPENPOSE_IMAGE_NAME) .. -f openpose/Dockerfile
+	docker build -t $(MMPOSE_IMAGE_NAME) .. -f mmpose/Dockerfile
 
 .PHONY: push
 push:
+ifeq ($(CURRENT_BRANCH),$(PROD_BRANCH))
 	aws ecr get-login-password --region us-west-2 --profile opencap | docker login --username AWS --password-stdin 660440363484.dkr.ecr.us-west-2.amazonaws.com
 
-	docker push $(BASE_NAME)/$(REPO_NAME)/$(OPENCAP_IMAGE_TAG)
-	docker push $(BASE_NAME)/$(REPO_NAME)/$(OPENPOSE_IMAGE_TAG)
-	docker push $(BASE_NAME)/$(REPO_NAME)/$(MMPOSE_IMAGE_TAG)
+	docker push $(OPENCAP_IMAGE_NAME)
+	docker push $(OPENPOSE_IMAGE_NAME)
+	docker push $(MMPOSE_IMAGE_NAME)
+
+else ifeq ($(CURRENT_BRANCH),$(DEV_BRANCH))
+	aws ecr get-login-password --region us-west-2 --profile opencap | docker login --username AWS --password-stdin 660440363484.dkr.ecr.us-west-2.amazonaws.com
+
+	docker push $(OPENCAP_IMAGE_NAME)
+	docker push $(OPENPOSE_IMAGE_NAME)
+	docker push $(MMPOSE_IMAGE_NAME)
+
+else
+	@echo "Git branch is not 'main' or 'dev', skipping push step"
+
+endif
 
 .PHONY: run
 run:
+ifeq ($(CURRENT_BRANCH),$(PROD_BRANCH))
 	aws ecr get-login-password --region us-west-2 --profile opencap | docker login --username AWS --password-stdin 660440363484.dkr.ecr.us-west-2.amazonaws.com
-	docker-compose up
+	
+else ifeq ($(CURRENT_BRANCH),$(DEV_BRANCH))
+	aws ecr get-login-password --region us-west-2 --profile opencap | docker login --username AWS --password-stdin 660440363484.dkr.ecr.us-west-2.amazonaws.com
+
+endif
+
+	OPENCAP_IMAGE_NAME=$(OPENCAP_IMAGE_NAME) OPENPOSE_IMAGE_NAME=$(OPENPOSE_IMAGE_NAME) MMPOSE_IMAGE_NAME=$(MMPOSE_IMAGE_NAME) docker-compose up

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   mobilecap:
-    image: 660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/opencap
+    image: ${OPENCAP_IMAGE_NAME}
     volumes:
       - data:/data
     env_file:
@@ -16,7 +16,7 @@ services:
               count: 1
               capabilities: [gpu]
   openpose:
-    image: 660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/openpose
+    image: ${OPENPOSE_IMAGE_NAME}
     volumes:
       - data:/openpose/data
     deploy:
@@ -27,7 +27,7 @@ services:
               count: 1
               capabilities: [gpu]
   mmpose:
-    image: 660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/mmpose
+    image: ${MMPOSE_IMAGE_NAME}
     volumes:
       - data:/mmpose/data
     deploy:


### PR DESCRIPTION
Addresses #200. 

Currently, this still uses the branch name to decide whether to push the `main` or `dev` image, or if it's neither branch, then do a local build (avoiding needing an extra argument when using the Makefile).

While I think this is a helpful PR in itself because it streamlines the development and merge steps, it seems like the Makefile does not in fact use the images from AWS (i.e., the `make` step builds a local container, and the `make run` step runs the container). I think some `docker pull` and `docker run` steps would be necessary, but perhaps I'm missing some step in the files here. I would lean towards pushing that to a different issue/PR if we want that.