### PR TITLE
Add retry mechanism to many database requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,4 @@ Examples/reprocessDataServer.py
 *.ini
 *.stats
 
-tests/
-
 newsletter.py

--- a/app.py
+++ b/app.py
@@ -67,9 +67,8 @@ while True:
     # no query string -> defaults to 'all'
     queue_path = "trials/dequeue/?workerType=" + workerType
     try:
-        r = makeRequestWithRetry('GET',
-                                 "{}{}".format(API_URL, queue_path),
-                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = requests.get("{}{}".format(API_URL, queue_path),
+                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
     except Exception as e:
         traceback.print_exc()
         time.sleep(15)

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from utilsAuth import getToken
 from utils import (getDataDirectory, checkTime, checkResourceUsage,
                   sendStatusEmail, checkForTrialsWithStatus,
                   getCommitHash, getHostname, postLocalClientInfo,
-                  postProcessedDuration)
+                  postProcessedDuration, makeRequestWithRetry)
 
 logging.basicConfig(level=logging.INFO)
 
@@ -67,8 +67,9 @@ while True:
     # no query string -> defaults to 'all'
     queue_path = "trials/dequeue/?workerType=" + workerType
     try:
-        r = requests.get("{}{}".format(API_URL, queue_path),
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('GET',
+                                 "{}{}".format(API_URL, queue_path),
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
     except Exception as e:
         traceback.print_exc()
         time.sleep(15)
@@ -120,8 +121,10 @@ while True:
         error_msg['error_msg'] = 'No videos uploaded. Ensure phones are connected and you have stable internet connection.'
         error_msg['error_msg_dev'] = 'No videos uploaded.'
 
-        r = requests.patch(trial_url, data={"status": "error", "meta": json.dumps(error_msg)},
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('PATCH',
+                                 trial_url,
+                                 data={"status": "error", "meta": json.dumps(error_msg)},
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
         continue
 
     # The following is now done in main, to allow reprocessing trials with missing videos
@@ -149,14 +152,18 @@ while True:
 
         # note a result needs to be posted for the API to know we finished, but we are posting them 
         # automatically thru procesTrial now
-        r = requests.patch(trial_url, data={"status": "done"},
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('PATCH',
+                                 trial_url,
+                                 data={"status": "done"},
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
+
         logging.info('0.5s pause if need to restart.')
         time.sleep(0.5)
 
     except Exception as e:
-        r = requests.patch(trial_url, data={"status": "error"},
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('PATCH',
+                                 trial_url, data={"status": "error"},
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
         traceback.print_exc()
 
         # Antoine: Removing this, it is too often causing the machines to stop. Not because

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ openpyxl
 ffmpeg-python
 psutil
 boto3
+pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,27 +1,74 @@
 import logging
 import pytest
 import requests
+from unittest.mock import patch, Mock, ANY
+from http.client import HTTPMessage
 
 from utils import makeRequestWithRetry
 
 class TestMakeRequestWithRetry:
     logging.getLogger('urllib3').setLevel(logging.DEBUG)
 
-    def test_get(self):
-        # should work and return 200
-        response = makeRequestWithRetry('GET', 'https://httpbin.org/get')
-        assert response.status_code == 200
-        assert response.json()['url'] == 'https://httpbin.org/get'
-    
-    def test_500(self):
-        # use an error code that triggers retries (should show up in debug log)
-        with pytest.raises(Exception):
-            response_500 = makeRequestWithRetry('GET', 'https://httpbin.org/status/500', retries=3, backoff_factor=0.1)
-    
-    def test_404(self):
-        # error code that won't trigger retries
-        with pytest.raises(Exception):
-            response_404 = makeRequestWithRetry('GET', 'https://httpbin.org/status/404', retires=2, backoff_factor=0.01)
+    @patch("requests.Session.request")
+    def test_get(self, mock_response):
+        status_code = 200
+        mock_response.return_value.status_code = status_code
 
-if __name__ == '__main__':
-    unittest.main()
+        response = makeRequestWithRetry('GET', 'https://test.com', retries=2)
+        assert response.status_code == status_code
+        mock_response.assert_called_once_with('GET', 'https://test.com',
+                                             headers=ANY, data=ANY, params=ANY)
+
+    @patch("requests.Session.request")
+    def test_put(self, mock_response):
+        status_code = 201
+        mock_response.return_value.status_code = status_code
+        
+        data = {
+            "key1": "value1",
+            "key2": "value2"
+        }
+
+        params = {
+            "param1": "value1"
+        }
+        
+        response = makeRequestWithRetry('POST', 
+                                        'https://test.com',
+                                        data=data,
+                                        headers={"Authorization": "my_token"},
+                                        params=params,
+                                        retries=2)
+        
+        assert response.status_code == status_code
+        mock_response.assert_called_once_with('POST', 
+                                             'https://test.com',
+                                             data=data,
+                                             headers={"Authorization": "my_token"},
+                                             params=params)
+
+    @patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+    def test_success_after_retries(self, mock_response):
+        mock_response.return_value.getresponse.side_effect = [
+            Mock(status=500, msg=HTTPMessage()),
+            Mock(status=502, msg=HTTPMessage()),
+            Mock(status=200, msg=HTTPMessage()),
+            Mock(status=429, msg=HTTPMessage()),
+        ]
+
+        response = makeRequestWithRetry('GET', 
+                                        'https://test.com', 
+                                        retries=5, 
+                                        backoff_factor=0.1)
+
+        assert response.status_code == 200
+        assert mock_response.call_count == 3
+
+    # comment out test since httpbin can be unstable and we don't want to rely
+    # on it for tests. uncomment and see debug log to see retry attempts
+    '''def test_httpbin(self):
+        response = makeRequestWithRetry('GET', 
+                                        'https://httpbin.org/status/500', 
+                                        retries=4, 
+                                        backoff_factor=0.1)
+    '''

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,9 @@
+from utils import makeRequestWithRetry
+
+def test_makeRequestWithRetry(self):
+    test_URL = 'http://httpbin.org/status/404'
+
+    makeRequestWithRetry('GET', test_URL)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,27 @@
+import logging
+import pytest
+import requests
+
 from utils import makeRequestWithRetry
 
-def test_makeRequestWithRetry(self):
-    test_URL = 'http://httpbin.org/status/404'
+class TestMakeRequestWithRetry:
+    logging.getLogger('urllib3').setLevel(logging.DEBUG)
 
-    makeRequestWithRetry('GET', test_URL)
+    def test_get(self):
+        # should work and return 200
+        response = makeRequestWithRetry('GET', 'https://httpbin.org/get')
+        assert response.status_code == 200
+        assert response.json()['url'] == 'https://httpbin.org/get'
+    
+    def test_500(self):
+        # use an error code that triggers retries (should show up in debug log)
+        with pytest.raises(Exception):
+            response_500 = makeRequestWithRetry('GET', 'https://httpbin.org/status/500', retries=3, backoff_factor=0.1)
+    
+    def test_404(self):
+        # error code that won't trigger retries
+        with pytest.raises(Exception):
+            response_404 = makeRequestWithRetry('GET', 'https://httpbin.org/status/404', retires=2, backoff_factor=0.01)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,10 @@ class TestMakeRequestWithRetry:
         response = makeRequestWithRetry('GET', 'https://test.com', retries=2)
         assert response.status_code == status_code
         mock_response.assert_called_once_with('GET', 'https://test.com',
-                                             headers=ANY, data=ANY, params=ANY)
+                                              headers=None,
+                                              data=None,
+                                              params=None,
+                                              files=None)
 
     @patch("requests.Session.request")
     def test_put(self, mock_response):
@@ -45,7 +48,8 @@ class TestMakeRequestWithRetry:
                                              'https://test.com',
                                              data=data,
                                              headers={"Authorization": "my_token"},
-                                             params=params)
+                                             params=params,
+                                             files=None)
 
     @patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
     def test_success_after_retries(self, mock_response):

--- a/utils.py
+++ b/utils.py
@@ -103,13 +103,17 @@ def download_file(url, file_name):
         shutil.copyfileobj(response, out_file)
         
 def getTrialJson(trial_id):
-    trialJson = requests.get(API_URL + "trials/{}/".format(trial_id),
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "trials/{}/".format(trial_id),
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    trialJson = response.json()
     return trialJson
 
 def getSessionJson(session_id):
-    sessionJson = requests.get(API_URL + "sessions/{}/".format(session_id),
-                       headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "sessions/{}/".format(session_id),
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    sessionJson = response.json()
     
     # sort trials by time recorded
     def getCreatedAt(trial):
@@ -119,8 +123,10 @@ def getSessionJson(session_id):
     return sessionJson
 
 def getSubjectJson(subject_id):
-    subjectJson = requests.get(API_URL + "subjects/{}/".format(subject_id),
-                       headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "subjects/{}/".format(subject_id),
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    subjectJson = response.json()
     return subjectJson
     
 def getTrialName(trial_id):
@@ -183,8 +189,10 @@ def postCalibrationOptions(session_path,session_id,overwrite=False):
                 "meta":json.dumps({'calibration':calibOptionsJson})
             }
         trial_url = "{}{}{}/".format(API_URL, "trials/", calibration_id)
-        r= requests.patch(trial_url, data=data,
-              headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('PATCH',
+                                 trial_url,
+                                 data=data,
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
         
         if r.status_code == 200:
             print('Wrote calibration selections to metadata.')
@@ -458,8 +466,9 @@ def deleteResult(trial_id, tag=None,resultNum=None):
         resultNums = [r['id'] for r in trial['results']]
 
     for rNum in resultNums:
-        requests.delete(API_URL + "results/{}/".format(rNum),
-                        headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        makeRequestWithRetry('DELETE',
+                             API_URL + "results/{}/".format(rNum),
+                             headers = {"Authorization": "Token {}".format(API_TOKEN)})
         
 def deleteAllResults(session_id):
 
@@ -687,8 +696,10 @@ def changeSessionMetadata(session_ids,newMetaDict):
         
         data = {"meta":json.dumps(existingMeta)}
         
-        r= requests.patch(session_url, data=data,
-              headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        r = makeRequestWithRetry('PATCH',
+                                 session_url,
+                                 data=data,
+                                 headers = {"Authorization": "Token {}".format(API_TOKEN)})
         
         if r.status_code !=200:
             print('Changing metadata failed.')
@@ -735,9 +746,11 @@ def makeSessionPublic(session_id,publicStatus=True):
     data = {
             "public":publicStatus
         }
-        
-    r= requests.patch(session_url, data=data,
-          headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    
+    r = makeRequestWithRetry('PATCH',
+                             session_url,
+                             data=data,
+                             headers = {"Authorization": "Token {}".format(API_TOKEN)})
     
     if r.status_code == 200:
         print('Successfully made ' + session_id + ' public.')
@@ -861,11 +874,17 @@ def postFileToTrial(filePath,trial_id,tag,device_id):
         
     # get S3 link
     data = {'fileName':os.path.split(filePath)[1]}
-    r = requests.get(API_URL + "sessions/null/get_presigned_url/",data=data).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "sessions/null/get_presigned_url/",
+                                    data=data)
+    r = response.json()
     
     # upload to S3
     files = {'file': open(filePath, 'rb')}
-    requests.post(r['url'], data=r['fields'],files=files)   
+    makeRequestWithRetry('POST',
+                         r['url'],
+                         data=r['fields'],
+                         files=files)
     files["file"].close()
 
     # post link to and data to results   
@@ -876,8 +895,10 @@ def postFileToTrial(filePath,trial_id,tag,device_id):
         "media_url" : r['fields']['key']
     }
     
-    rResult = requests.post(API_URL + "results/", data=data,
-                  headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    rResult = makeRequestWithRetry('POST',
+                                   API_URL + "results/", 
+                                   data=data,
+                                   headers = {"Authorization": "Token {}".format(API_TOKEN)})
     
     if rResult.status_code != 201:
         print('server response was + ' + str(r.status_code))
@@ -1484,8 +1505,11 @@ def checkForTrialsWithStatus(status,hours=9999999,relativeTime='newer'):
               'justNumber':1,
               'relativeTime':relativeTime}
     
-    r = requests.get(API_URL+"trials/get_trials_with_status/",params=params,
-        headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL+"trials/get_trials_with_status/",
+                                    params=params,
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    r = response.json()
     
     return r['nTrials']
 
@@ -1565,8 +1589,10 @@ def checkCudaTF():
 # %% Some functions for loading subject data
 
 def getSubjectNumber(subjectName):
-    subjects = requests.get(API_URL + "subjects/",
-                           headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "subjects/",
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    subjects = response.json()
     sNum = [s['id'] for s in subjects if s['name'] == subjectName]
     if len(sNum)>1:
         print(len(sNum) + ' subjects with the name ' + subjectName + '. Will use the first one.')   
@@ -1576,8 +1602,10 @@ def getSubjectNumber(subjectName):
     return sNum[0]
 
 def getUserSessions():
-    sessionJson = requests.get(API_URL + "sessions/valid/",
-                           headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
+    response = makeRequestWithRetry('GET',
+                                    API_URL + "sessions/valid/",
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    sessionJson = response.json()
     return sessionJson
 
 def getSubjectSessions(subjectName):
@@ -1639,8 +1667,10 @@ def postLocalClientInfo(trial_url):
             "git_commit": getCommitHash(),
             "hostname": getHostname()
         }
-    r = requests.patch(trial_url, data=data,
-          headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    r = makeRequestWithRetry('PATCH',
+                             trial_url,
+                             data=data,
+                             headers = {"Authorization": "Token {}".format(API_TOKEN)})
     
     return r
 
@@ -1651,23 +1681,26 @@ def postProcessedDuration(trial_url, duration):
     data = {
         "processed_duration": duration
     }
-    r = requests.patch(trial_url, data=data,
-            headers = {"Authorization": "Token {}".format(API_TOKEN)})
+    r = makeRequestWithRetry('PATCH',
+                             trial_url,
+                             data=data,
+                             headers = {"Authorization": "Token {}".format(API_TOKEN)})
     
     return r
 
 # utils for common HTTP requests
 def makeRequestWithRetry(method, url,
-                         headers=None, data=None, params=None,
+                         headers=None, data=None, params=None, files=None,
                          retries=5, backoff_factor=1):
     """
     Makes an HTTP request with retry logic and returns the Response object.
 
     Args:
-        method (str): HTTP method (e.g., 'GET', 'POST', 'PUT', etc.).
+        method (str): HTTP method (e.g., 'GET', 'POST', 'PUT', etc.) as used in 
+            requests.Session().request()
         url (str): The endpoint URL.
         headers (dict): Headers to include in the request.
-        data (dict): Data to send in the request body (for POST/PUT requests).
+        data (dict): Data to send in the request body.
         params (dict): URL query parameters.
         retries (int): Number of retry attempts.
         backoff_factor (float): Backoff factor for exponential delays.
@@ -1680,7 +1713,7 @@ def makeRequestWithRetry(method, url,
             total=retries,
             backoff_factor=backoff_factor,
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods={'DELETE', 'GET', 'POST', 'PUT'}
+            allowed_methods={'DELETE', 'GET', 'POST', 'PUT', 'PATCH'}
         )
 
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
@@ -1690,7 +1723,8 @@ def makeRequestWithRetry(method, url,
                                        url,
                                        headers=headers,
                                        data=data,
-                                       params=params)
+                                       params=params,
+                                       files=files)
         response.raise_for_status()
         return response
             

--- a/utils.py
+++ b/utils.py
@@ -1679,14 +1679,15 @@ def makeRequestWithRetry(method, url,
         retry_strategy = Retry(
             total=retries,
             backoff_factor=backoff_factor,
-            status_forcelist=[429, 500, 502, 503, 504]
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods={'DELETE', 'GET', 'POST', 'PUT'}
         )
 
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         with requests.Session() as session:
             session.mount("https://", adapter)
-            response = session.request(method=method,
-                                       url=url,
+            response = session.request(method,
+                                       url,
                                        headers=headers,
                                        data=data,
                                        params=params)

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -24,6 +24,7 @@ import copy
 from utilsCameraPy3 import Camera, nview_linear_triangulations
 from utils import getOpenPoseMarkerNames, getOpenPoseFaceMarkers
 from utils import numpy2TRC, rewriteVideos, delete_multiple_element,loadCameraParameters
+from utils import makeRequestWithRetry
 from utilsAPI import getAPIURL
 
 from utilsAuth import getToken
@@ -198,8 +199,9 @@ def computeAverageIntrinsics(session_path,trialIDs,CheckerBoardParams,nImages=25
     camModels = []
     
     for trial_id in trialIDs:
-        resp = requests.get(API_URL + "trials/{}/".format(trial_id),
-                         headers = {"Authorization": "Token {}".format(API_TOKEN)})
+        resp = makeRequestWithRetry('GET',
+                                    API_URL + "trials/{}/".format(trial_id),
+                                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
         trial = resp.json()
         camModels.append(trial['videos'][0]['parameters']['model'])
         trial_name = trial['name']


### PR DESCRIPTION
Should help issues such as #189 and #192 that use the `requests` library. Requests are attempted one time and can fail if there are intermittent connectivity issues between the worker and database. This leads to errors that cannot be traced on the database, since it lost connection and cannot post to the database.

This adds a wrapper function to attempt multiple requests to these calls with an exponential backoff (e.g., attempt after 1 second, 2 seconds, 4 seconds, 16 seconds, 32 seconds).

@antoinefalisse @AlbertoCasasOrtiz I'm tagging you both (and would like a review from both) since it touches many important calls to the database. Some notes below:

Testing that's been done:
- Added tests for the new wrapper function
- Reprocessed a completed trial on dev. This, however, does not test all of the functions that have been updated.

Notes for review:
- What other testing should be done (both now, before it gets merged into dev, and also before we merge into main)? At least a full session with new data collection on dev should be done before main.
- This adds a `tests` folder, which required removing it from the `.gitignore` file. Will this mess up someone's workflow?
- Would you like to see a smaller set of changes first? The change has been applied pretty broadly at this point, but we can use a smaller set of changes first and monitor if that's helpful.