### PR TITLE
Add exhaustive calibration fallback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+
+TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
+REPO_DIR = os.path.abspath(os.path.join(TESTS_DIR, '../'))
+TEST_DATA_ROOT = os.path.join(TESTS_DIR, 'opencap-test-data')
+TEST_DATA_DIR = os.path.join(TEST_DATA_ROOT, 'Data')
+CALIBRATION_FIXTURE_DIR = os.path.join(TEST_DATA_DIR, 'calibration-fixtures')

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,387 @@
+import os
+import shutil
+import sys
+
+import cv2
+import numpy as np
+import pytest
+
+os.environ.setdefault('API_TOKEN', 'test-token')
+
+thisDir = os.path.dirname(os.path.realpath(__file__))
+repoDir = os.path.abspath(os.path.join(thisDir, '../'))
+sys.path.append(repoDir)
+
+from utilsChecker import (
+    calcExtrinsicsFromVideo,
+    generate3Dgrid,
+    loadCameraParameters,
+    rotateIntrinsics,
+)
+
+
+STANDARD_CHECKERBOARD_PARAMS = {
+    'dimensions': (5, 4),
+    'squareSize': 35.0,
+}
+LABVALIDATION_CHECKERBOARD_PARAMS = {
+    'dimensions': (11, 8),
+    'squareSize': 60.0,
+}
+MAX_MEAN_REPROJECTION_ERROR_PX = 0.5
+
+ORIGINAL_FIND_CHESSBOARD_CORNERS = cv2.findChessboardCorners
+ORIGINAL_FIND_CHESSBOARD_CORNERS_SB_WITH_META = cv2.findChessboardCornersSBWithMeta
+ORIGINAL_CORNER_SUB_PIX = cv2.cornerSubPix
+
+CALIBRATION_FIXTURE_DIR = os.path.join(
+    thisDir,
+    'opencap-test-data',
+    'Data',
+    'calibration-fixtures',
+)
+IPHONE13_MODEL = 'iPhone13,3'
+IPHONE17_1_MODEL = 'iPhone17,1'
+IPHONE17_3_MODEL = 'iPhone17,3'
+INTRINSICS_FOLDER = 'Deployed'
+
+ACL_EXHAUSTIVE_FALLBACK_VIDEO = os.path.join(
+    CALIBRATION_FIXTURE_DIR,
+    'acl',
+    'exhaustive_fallback_success',
+    'acl_exhaustive_only_success.qt',
+)
+UTAH_PRODUCTION_VIDEO = os.path.join(
+    CALIBRATION_FIXTURE_DIR,
+    'utah',
+    'production_success',
+    'utah_production_success.mov',
+)
+
+PRIMARY_SUCCESS_FIXTURES = [
+    (
+        'acl',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'acl',
+            'primary_success',
+            'acl_primary_success.qt',
+        ),
+        STANDARD_CHECKERBOARD_PARAMS,
+        IPHONE13_MODEL,
+    ),
+    (
+        'labvalidation',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'labvalidation',
+            'primary_success',
+            'labvalidation_subject5_session0_cam3_extrinsics.avi',
+        ),
+        LABVALIDATION_CHECKERBOARD_PARAMS,
+        IPHONE13_MODEL,
+    ),
+]
+
+NEGATIVE_FIXTURES = [
+    (
+        'no_checkerboard_cam0',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'comprehensive',
+            'no_checkerboard',
+            'no_checkerboard_cam0.mov',
+        ),
+        IPHONE17_3_MODEL,
+    ),
+    (
+        'no_checkerboard_cam1',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'comprehensive',
+            'no_checkerboard',
+            'no_checkerboard_cam1.mov',
+        ),
+        IPHONE17_1_MODEL,
+    ),
+    (
+        'partial_checkerboard_cam0',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'comprehensive',
+            'partial_checkerboard',
+            'partial_checkerboard_cam0.mov',
+        ),
+        IPHONE17_3_MODEL,
+    ),
+    (
+        'partial_checkerboard_cam1',
+        os.path.join(
+            CALIBRATION_FIXTURE_DIR,
+            'comprehensive',
+            'partial_checkerboard',
+            'partial_checkerboard_cam1.mov',
+        ),
+        IPHONE17_1_MODEL,
+    ),
+]
+
+
+def load_intrinsics(video_path, iphone_model):
+    intrinsics_path = os.path.join(
+        repoDir,
+        'CameraIntrinsics',
+        iphone_model,
+        INTRINSICS_FOLDER,
+        'cameraIntrinsics.pickle',
+    )
+    camera_params = loadCameraParameters(intrinsics_path)
+    return rotateIntrinsics(camera_params, str(video_path))
+
+
+def input_media_dir(tmp_path):
+    media_dir = (
+        tmp_path
+        / 'Data'
+        / 'test_session'
+        / 'Videos'
+        / 'Cam0'
+        / 'InputMedia'
+        / 'calibration'
+    )
+    media_dir.mkdir(parents=True, exist_ok=True)
+    return media_dir
+
+
+def stage_video(tmp_path, video_path):
+    staged_video_path = input_media_dir(tmp_path) / os.path.basename(video_path)
+    shutil.copy2(video_path, staged_video_path)
+    return staged_video_path
+
+
+def assert_extrinsics(camera_params):
+    assert camera_params is not None
+    for key in ('rotation', 'translation', 'rotation_EulerAngles'):
+        assert key in camera_params
+        assert np.all(np.isfinite(camera_params[key]))
+    assert camera_params['rotation'].shape == (3, 3)
+    assert camera_params['translation'].shape in ((3, 1), (3,))
+
+
+def sb_flags(exhaustive):
+    flags = cv2.CALIB_CB_ACCURACY | cv2.CALIB_CB_LARGER
+    if exhaustive:
+        flags |= cv2.CALIB_CB_EXHAUSTIVE
+    return flags
+
+
+def mean_reproj_error(camera_params, checkerboard_params, corners, image_shape):
+    if camera_params is None or corners is None or image_shape is None:
+        return None
+
+    image_width = image_shape[1]
+    camera_image_width = float(np.squeeze(camera_params['imageSize'])[1])
+    scale = image_width / camera_image_width
+    observed_corners = corners / scale
+    object_points = generate3Dgrid(checkerboard_params)
+    projected_corners, _ = cv2.projectPoints(
+        object_points,
+        camera_params['rotation_EulerAngles'],
+        camera_params['translation'],
+        camera_params['intrinsicMat'],
+        camera_params['distortion'],
+    )
+    corner_errors = np.linalg.norm(
+        projected_corners.reshape(-1, 2) - observed_corners.reshape(-1, 2),
+        axis=1,
+    )
+    return float(np.mean(corner_errors))
+
+
+def run_video_calibration(
+    video_path,
+    checkerboard_params,
+    iphone_model,
+    tmp_path,
+    monkeypatch,
+    detector_mode,
+):
+    staged_video_path = stage_video(tmp_path, video_path)
+    camera_params = load_intrinsics(staged_video_path, iphone_model)
+    calls = {'primary': 0, 'fallback': 0}
+    production_flags = []
+    detector_flags = []
+    detected = {'corners': None, 'image_shape': None}
+
+    def primary_detector(*args, **kwargs):
+        calls['primary'] += 1
+        found, corners = ORIGINAL_FIND_CHESSBOARD_CORNERS(*args, **kwargs)
+        if found:
+            detected['corners'] = corners.copy()
+            detected['image_shape'] = args[0].shape
+        return found, corners
+
+    def fallback_detector(image, pattern_size, flags):
+        calls['fallback'] += 1
+        production_flags.append(flags)
+        if detector_mode == 'primary_only':
+            return False, None, None
+        if detector_mode == 'current_fallback':
+            flags = sb_flags(exhaustive=False)
+        elif detector_mode == 'exhaustive_fallback':
+            flags = sb_flags(exhaustive=True)
+        detector_flags.append(flags)
+        found, corners, meta = ORIGINAL_FIND_CHESSBOARD_CORNERS_SB_WITH_META(
+            image, pattern_size, flags
+        )
+        if found:
+            detected['corners'] = corners.copy()
+            detected['image_shape'] = image.shape
+        return found, corners, meta
+
+    def corner_subpix(image, corners, win_size, zero_zone, criteria):
+        refined_corners = ORIGINAL_CORNER_SUB_PIX(
+            image, corners, win_size, zero_zone, criteria
+        )
+        detected['corners'] = refined_corners.copy()
+        detected['image_shape'] = image.shape
+        return refined_corners
+
+    monkeypatch.setattr(cv2, 'findChessboardCorners', primary_detector)
+    monkeypatch.setattr(cv2, 'findChessboardCornersSBWithMeta', fallback_detector)
+    monkeypatch.setattr(cv2, 'cornerSubPix', corner_subpix)
+
+    try:
+        result = calcExtrinsicsFromVideo(
+            str(staged_video_path),
+            camera_params,
+            checkerboard_params,
+            visualize=False,
+            imageUpsampleFactor=2,
+        )
+    except Exception as exc:
+        if 'checkerboard was not detected' not in str(exc):
+            raise
+        result = None
+    error = mean_reproj_error(
+        result, checkerboard_params, detected['corners'], detected['image_shape']
+    )
+    return result, calls, production_flags, detector_flags, error
+
+
+@pytest.mark.parametrize(
+    'fixture_name, video_path, checkerboard_params, iphone_model',
+    PRIMARY_SUCCESS_FIXTURES,
+    ids=[fixture[0] for fixture in PRIMARY_SUCCESS_FIXTURES],
+)
+# Good videos that should work with no fallback
+def test_primary_fixtures_calibrate(
+    fixture_name, video_path, checkerboard_params, iphone_model, tmp_path, monkeypatch
+):
+    result, calls, production_flags, detector_flags, mean_error = run_video_calibration(
+        video_path,
+        checkerboard_params,
+        iphone_model,
+        tmp_path,
+        monkeypatch,
+        detector_mode='primary_only',
+    )
+
+    assert_extrinsics(result)
+    assert mean_error < MAX_MEAN_REPROJECTION_ERROR_PX, (
+        fixture_name,
+        mean_error,
+    )
+    assert calls['primary'] == 1
+    assert calls['fallback'] == 0
+    assert production_flags == []
+    assert detector_flags == []
+
+
+# Utah vid should succeed through the production fallback route (and in many cases via primary detector)
+def test_utah_production_calibrates(tmp_path, monkeypatch):
+    result, _, _, _, mean_error = run_video_calibration(
+        UTAH_PRODUCTION_VIDEO,
+        STANDARD_CHECKERBOARD_PARAMS,
+        IPHONE13_MODEL,
+        tmp_path,
+        monkeypatch,
+        detector_mode='exhaustive_fallback',
+    )
+
+    assert_extrinsics(result)
+    assert mean_error < MAX_MEAN_REPROJECTION_ERROR_PX, mean_error
+
+
+# A hard ACL vid that fails with the old fallback but succeeds with the new exhaustive fallback
+def test_acl_exhaustive_recovery(tmp_path, monkeypatch):
+    (
+        current_result,
+        current_calls,
+        current_production_flags,
+        current_flags,
+        _,
+    ) = run_video_calibration(
+        ACL_EXHAUSTIVE_FALLBACK_VIDEO,
+        STANDARD_CHECKERBOARD_PARAMS,
+        IPHONE13_MODEL,
+        tmp_path / 'current_fallback',
+        monkeypatch,
+        detector_mode='current_fallback',
+    )
+    assert current_result is None
+    assert current_calls['fallback'] > 0
+    assert current_production_flags
+    assert current_flags
+    assert not any(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in current_flags)
+
+    (
+        exhaustive_result,
+        exhaustive_calls,
+        exhaustive_production_flags,
+        exhaustive_flags,
+        mean_error,
+    ) = run_video_calibration(
+        ACL_EXHAUSTIVE_FALLBACK_VIDEO,
+        STANDARD_CHECKERBOARD_PARAMS,
+        IPHONE13_MODEL,
+        tmp_path / 'exhaustive_fallback',
+        monkeypatch,
+        detector_mode='exhaustive_fallback',
+    )
+
+    assert_extrinsics(exhaustive_result)
+    assert mean_error < MAX_MEAN_REPROJECTION_ERROR_PX, mean_error
+    assert exhaustive_calls['fallback'] > 0
+    assert exhaustive_production_flags
+    assert exhaustive_flags
+    assert any(
+        flags & cv2.CALIB_CB_EXHAUSTIVE for flags in exhaustive_production_flags
+    )
+    assert any(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in exhaustive_flags)
+
+
+@pytest.mark.parametrize(
+    'fixture_name, video_path, iphone_model',
+    NEGATIVE_FIXTURES,
+    ids=[fixture[0] for fixture in NEGATIVE_FIXTURES],
+)
+# No board and partial board should fail even with exhaustive fallback
+def test_negative_fixtures_reject(
+    fixture_name, video_path, iphone_model, tmp_path, monkeypatch
+):
+    result, calls, production_flags, detector_flags, _ = run_video_calibration(
+        video_path,
+        STANDARD_CHECKERBOARD_PARAMS,
+        iphone_model,
+        tmp_path,
+        monkeypatch,
+        detector_mode='exhaustive_fallback',
+    )
+
+    assert result is None, fixture_name
+    assert calls['fallback'] > 0
+    assert production_flags
+    assert detector_flags
+    assert all(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in production_flags)
+    assert all(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in detector_flags)

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -8,10 +8,11 @@ import pytest
 
 os.environ.setdefault('API_TOKEN', 'test-token')
 
-thisDir = os.path.dirname(os.path.realpath(__file__))
-repoDir = os.path.abspath(os.path.join(thisDir, '../'))
-sys.path.append(repoDir)
+from conftest import CALIBRATION_FIXTURE_DIR, REPO_DIR
 
+sys.path.append(REPO_DIR)
+
+import utilsChecker
 from utilsChecker import (
     calcExtrinsicsFromVideo,
     generate3Dgrid,
@@ -20,7 +21,9 @@ from utilsChecker import (
 )
 
 
-STANDARD_CHECKERBOARD_PARAMS = {
+# ---- Checkerboard / fixture constants ----
+
+DEFAULT_CHECKERBOARD_PARAMS = {
     'dimensions': (5, 4),
     'squareSize': 35.0,
 }
@@ -30,19 +33,7 @@ LABVALIDATION_CHECKERBOARD_PARAMS = {
 }
 MAX_MEAN_REPROJECTION_ERROR_PX = 0.5
 
-ORIGINAL_FIND_CHESSBOARD_CORNERS = cv2.findChessboardCorners
-ORIGINAL_FIND_CHESSBOARD_CORNERS_SB_WITH_META = cv2.findChessboardCornersSBWithMeta
-ORIGINAL_CORNER_SUB_PIX = cv2.cornerSubPix
 
-CALIBRATION_FIXTURE_DIR = os.path.join(
-    thisDir,
-    'opencap-test-data',
-    'Data',
-    'calibration-fixtures',
-)
-IPHONE13_MODEL = 'iPhone13,3'
-IPHONE17_1_MODEL = 'iPhone17,1'
-IPHONE17_3_MODEL = 'iPhone17,3'
 INTRINSICS_FOLDER = 'Deployed'
 
 ACL_EXHAUSTIVE_FALLBACK_VIDEO = os.path.join(
@@ -51,7 +42,7 @@ ACL_EXHAUSTIVE_FALLBACK_VIDEO = os.path.join(
     'exhaustive_fallback_success',
     'acl_exhaustive_only_success.qt',
 )
-UTAH_PRODUCTION_VIDEO = os.path.join(
+UTAH_FIXTURE_VIDEO = os.path.join(
     CALIBRATION_FIXTURE_DIR,
     'utah',
     'production_success',
@@ -67,8 +58,8 @@ PRIMARY_SUCCESS_FIXTURES = [
             'primary_success',
             'acl_primary_success.qt',
         ),
-        STANDARD_CHECKERBOARD_PARAMS,
-        IPHONE13_MODEL,
+        DEFAULT_CHECKERBOARD_PARAMS,
+        'iPhone13,3',
     ),
     (
         'labvalidation',
@@ -79,7 +70,7 @@ PRIMARY_SUCCESS_FIXTURES = [
             'labvalidation_subject5_session0_cam3_extrinsics.avi',
         ),
         LABVALIDATION_CHECKERBOARD_PARAMS,
-        IPHONE13_MODEL,
+        'iPhone13,3',
     ),
 ]
 
@@ -92,7 +83,7 @@ NEGATIVE_FIXTURES = [
             'no_checkerboard',
             'no_checkerboard_cam0.mov',
         ),
-        IPHONE17_3_MODEL,
+        'iPhone17,3',
     ),
     (
         'no_checkerboard_cam1',
@@ -102,7 +93,7 @@ NEGATIVE_FIXTURES = [
             'no_checkerboard',
             'no_checkerboard_cam1.mov',
         ),
-        IPHONE17_1_MODEL,
+        'iPhone17,1',
     ),
     (
         'partial_checkerboard_cam0',
@@ -112,7 +103,7 @@ NEGATIVE_FIXTURES = [
             'partial_checkerboard',
             'partial_checkerboard_cam0.mov',
         ),
-        IPHONE17_3_MODEL,
+        'iPhone17,3',
     ),
     (
         'partial_checkerboard_cam1',
@@ -122,14 +113,26 @@ NEGATIVE_FIXTURES = [
             'partial_checkerboard',
             'partial_checkerboard_cam1.mov',
         ),
-        IPHONE17_1_MODEL,
+        'iPhone17,1',
     ),
 ]
 
 
+# ---- Unpatched cv2 handles ----
+
+UNPATCHED_CV2_FIND_CHESSBOARD_CORNERS = cv2.findChessboardCorners
+UNPATCHED_CV2_FIND_CHESSBOARD_CORNERS_SB_WITH_META = (
+    cv2.findChessboardCornersSBWithMeta
+)
+UNPATCHED_CV2_CORNER_SUB_PIX = cv2.cornerSubPix
+UNPATCHED_ENSURE_CORNER_ORDERING = utilsChecker.ensureCornerOrdering
+
+
+# ---- Helpers ----
+
 def load_intrinsics(video_path, iphone_model):
     intrinsics_path = os.path.join(
-        repoDir,
+        REPO_DIR,
         'CameraIntrinsics',
         iphone_model,
         INTRINSICS_FOLDER,
@@ -140,14 +143,15 @@ def load_intrinsics(video_path, iphone_model):
 
 
 def input_media_dir(tmp_path):
-    media_dir = (
-        tmp_path
-        / 'Data'
-        / 'test_session'
-        / 'Videos'
-        / 'Cam0'
-        / 'InputMedia'
-        / 'calibration'
+    media_dir = tmp_path.joinpath(
+        os.path.join(
+            'Data',
+            'test_session',
+            'Videos',
+            'Cam0',
+            'InputMedia',
+            'calibration',
+        )
     )
     media_dir.mkdir(parents=True, exist_ok=True)
     return media_dir
@@ -182,6 +186,8 @@ def mean_reproj_error(camera_params, checkerboard_params, corners, image_shape):
     image_width = image_shape[1]
     camera_image_width = float(np.squeeze(camera_params['imageSize'])[1])
     scale = image_width / camera_image_width
+    # Need to scale as detected coreners are potentially from upsampled/downsampled image,
+    # but checking agaisnt original camera intrinsics
     observed_corners = corners / scale
     object_points = generate3Dgrid(checkerboard_params)
     projected_corners, _ = cv2.projectPoints(
@@ -204,52 +210,72 @@ def run_video_calibration(
     iphone_model,
     tmp_path,
     monkeypatch,
-    detector_mode,
+    fallback_enabled=True,
+    fallback_flag_override=None,
 ):
     staged_video_path = stage_video(tmp_path, video_path)
     camera_params = load_intrinsics(staged_video_path, iphone_model)
     calls = {'primary': 0, 'fallback': 0}
-    production_flags = []
-    detector_flags = []
-    detected = {'corners': None, 'image_shape': None}
+    fallback_flags = []
+    # captured_corners stores corners detected by the different methods,
+    # pre and post sub pixel refining for primary path and pre and 
+    # post re-ordering for fallback path
+    captured_corners = {
+        'raw_primary': None,
+        'refined_primary': None,
+        'raw_sb': None,
+        'ordered_sb': None,
+        'image_shape': None,
+    }
 
     def primary_detector(*args, **kwargs):
         calls['primary'] += 1
-        found, corners = ORIGINAL_FIND_CHESSBOARD_CORNERS(*args, **kwargs)
+        found, corners = UNPATCHED_CV2_FIND_CHESSBOARD_CORNERS(*args, **kwargs)
         if found:
-            detected['corners'] = corners.copy()
-            detected['image_shape'] = args[0].shape
+            captured_corners['raw_primary'] = corners.copy()
+            captured_corners['image_shape'] = args[0].shape
         return found, corners
 
+    # fallback_flags records flags across retries, the flags used are always those requested
+    # by prod except for the case where we test the old fallback without exhaustive
     def fallback_detector(image, pattern_size, flags):
         calls['fallback'] += 1
-        production_flags.append(flags)
-        if detector_mode == 'primary_only':
+        if not fallback_enabled:
             return False, None, None
-        if detector_mode == 'current_fallback':
-            flags = sb_flags(exhaustive=False)
-        elif detector_mode == 'exhaustive_fallback':
-            flags = sb_flags(exhaustive=True)
-        detector_flags.append(flags)
-        found, corners, meta = ORIGINAL_FIND_CHESSBOARD_CORNERS_SB_WITH_META(
+        if fallback_flag_override is not None:
+            flags = fallback_flag_override
+        fallback_flags.append(flags)
+        found, corners, meta = UNPATCHED_CV2_FIND_CHESSBOARD_CORNERS_SB_WITH_META(
             image, pattern_size, flags
         )
         if found:
-            detected['corners'] = corners.copy()
-            detected['image_shape'] = image.shape
+            captured_corners['raw_sb'] = corners.copy()
+            captured_corners['image_shape'] = image.shape
         return found, corners, meta
 
+    def ensure_corner_ordering(image, corners, pattern, squareResolution=1):
+        ordered_corners, ordering_success, ordering_error = (
+            UNPATCHED_ENSURE_CORNER_ORDERING(
+                image, corners, pattern, squareResolution=squareResolution
+            )
+        )
+        if ordering_success:
+            captured_corners['ordered_sb'] = ordered_corners.copy()
+            captured_corners['image_shape'] = image.shape
+        return ordered_corners, ordering_success, ordering_error
+
     def corner_subpix(image, corners, win_size, zero_zone, criteria):
-        refined_corners = ORIGINAL_CORNER_SUB_PIX(
+        refined_corners = UNPATCHED_CV2_CORNER_SUB_PIX(
             image, corners, win_size, zero_zone, criteria
         )
-        detected['corners'] = refined_corners.copy()
-        detected['image_shape'] = image.shape
+        captured_corners['refined_primary'] = refined_corners.copy()
+        captured_corners['image_shape'] = image.shape
         return refined_corners
 
     monkeypatch.setattr(cv2, 'findChessboardCorners', primary_detector)
     monkeypatch.setattr(cv2, 'findChessboardCornersSBWithMeta', fallback_detector)
     monkeypatch.setattr(cv2, 'cornerSubPix', corner_subpix)
+    monkeypatch.setattr(utilsChecker, 'ensureCornerOrdering', ensure_corner_ordering)
 
     try:
         result = calcExtrinsicsFromVideo(
@@ -263,11 +289,21 @@ def run_video_calibration(
         if 'checkerboard was not detected' not in str(exc):
             raise
         result = None
-    error = mean_reproj_error(
-        result, checkerboard_params, detected['corners'], detected['image_shape']
+    corners_for_reprojection = (
+        captured_corners['refined_primary']
+        if captured_corners['refined_primary'] is not None
+        else captured_corners['ordered_sb']
     )
-    return result, calls, production_flags, detector_flags, error
+    error = mean_reproj_error(
+        result,
+        checkerboard_params,
+        corners_for_reprojection,
+        captured_corners['image_shape'],
+    )
+    return result, calls, fallback_flags, error
 
+
+# ---- Tests ----
 
 @pytest.mark.parametrize(
     'fixture_name, video_path, checkerboard_params, iphone_model',
@@ -278,13 +314,15 @@ def run_video_calibration(
 def test_primary_fixtures_calibrate(
     fixture_name, video_path, checkerboard_params, iphone_model, tmp_path, monkeypatch
 ):
-    result, calls, production_flags, detector_flags, mean_error = run_video_calibration(
-        video_path,
-        checkerboard_params,
-        iphone_model,
-        tmp_path,
-        monkeypatch,
-        detector_mode='primary_only',
+    result, calls, fallback_flags, mean_error = (
+        run_video_calibration(
+            video_path,
+            checkerboard_params,
+            iphone_model,
+            tmp_path,
+            monkeypatch,
+            fallback_enabled=False,
+        )
     )
 
     assert_extrinsics(result)
@@ -292,21 +330,20 @@ def test_primary_fixtures_calibrate(
         fixture_name,
         mean_error,
     )
-    assert calls['primary'] == 1
+    # These fixtures should pass within the primary detector's resize attempts.
+    assert 1 <= calls['primary'] <= 4
     assert calls['fallback'] == 0
-    assert production_flags == []
-    assert detector_flags == []
+    assert fallback_flags == []
 
 
-# Utah vid should succeed through the production fallback route (and in many cases via primary detector)
-def test_utah_production_calibrates(tmp_path, monkeypatch):
-    result, _, _, _, mean_error = run_video_calibration(
-        UTAH_PRODUCTION_VIDEO,
-        STANDARD_CHECKERBOARD_PARAMS,
-        IPHONE13_MODEL,
+# Utah fixture should calibrate through the exhaustive fallback route when needed.
+def test_utah_fixture_exhaustive(tmp_path, monkeypatch):
+    result, _, _, mean_error = run_video_calibration(
+        UTAH_FIXTURE_VIDEO,
+        DEFAULT_CHECKERBOARD_PARAMS,
+        'iPhone13,3',
         tmp_path,
         monkeypatch,
-        detector_mode='exhaustive_fallback',
     )
 
     assert_extrinsics(result)
@@ -318,47 +355,44 @@ def test_acl_exhaustive_recovery(tmp_path, monkeypatch):
     (
         current_result,
         current_calls,
-        current_production_flags,
-        current_flags,
+        current_fallback_flags,
         _,
     ) = run_video_calibration(
         ACL_EXHAUSTIVE_FALLBACK_VIDEO,
-        STANDARD_CHECKERBOARD_PARAMS,
-        IPHONE13_MODEL,
+        DEFAULT_CHECKERBOARD_PARAMS,
+        'iPhone13,3',
         tmp_path / 'current_fallback',
         monkeypatch,
-        detector_mode='current_fallback',
+        fallback_flag_override=sb_flags(exhaustive=False),
     )
     assert current_result is None
     assert current_calls['fallback'] > 0
-    assert current_production_flags
-    assert current_flags
-    assert not any(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in current_flags)
+    assert current_fallback_flags
+    assert not any(
+        flags & cv2.CALIB_CB_EXHAUSTIVE for flags in current_fallback_flags
+    )
 
     (
         exhaustive_result,
         exhaustive_calls,
-        exhaustive_production_flags,
-        exhaustive_flags,
+        exhaustive_fallback_flags,
         mean_error,
     ) = run_video_calibration(
         ACL_EXHAUSTIVE_FALLBACK_VIDEO,
-        STANDARD_CHECKERBOARD_PARAMS,
-        IPHONE13_MODEL,
+        DEFAULT_CHECKERBOARD_PARAMS,
+        'iPhone13,3',
         tmp_path / 'exhaustive_fallback',
         monkeypatch,
-        detector_mode='exhaustive_fallback',
     )
 
     assert_extrinsics(exhaustive_result)
     assert mean_error < MAX_MEAN_REPROJECTION_ERROR_PX, mean_error
     assert exhaustive_calls['fallback'] > 0
-    assert exhaustive_production_flags
-    assert exhaustive_flags
+    assert exhaustive_fallback_flags
     assert any(
-        flags & cv2.CALIB_CB_EXHAUSTIVE for flags in exhaustive_production_flags
+        flags & cv2.CALIB_CB_EXHAUSTIVE
+        for flags in exhaustive_fallback_flags
     )
-    assert any(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in exhaustive_flags)
 
 
 @pytest.mark.parametrize(
@@ -370,18 +404,17 @@ def test_acl_exhaustive_recovery(tmp_path, monkeypatch):
 def test_negative_fixtures_reject(
     fixture_name, video_path, iphone_model, tmp_path, monkeypatch
 ):
-    result, calls, production_flags, detector_flags, _ = run_video_calibration(
-        video_path,
-        STANDARD_CHECKERBOARD_PARAMS,
-        iphone_model,
-        tmp_path,
-        monkeypatch,
-        detector_mode='exhaustive_fallback',
+    result, calls, fallback_flags, _ = (
+        run_video_calibration(
+            video_path,
+            DEFAULT_CHECKERBOARD_PARAMS,
+            iphone_model,
+            tmp_path,
+            monkeypatch,
+        )
     )
 
     assert result is None, fixture_name
     assert calls['fallback'] > 0
-    assert production_flags
-    assert detector_flags
-    assert all(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in production_flags)
-    assert all(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in detector_flags)
+    assert fallback_flags
+    assert all(flags & cv2.CALIB_CB_EXHAUSTIVE for flags in fallback_flags)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import pickle
+import shutil
 import sys
 import numpy as np
 import pandas as pd
@@ -9,6 +11,37 @@ thisDir = os.path.dirname(os.path.realpath(__file__))
 repoDir = os.path.abspath(os.path.join(thisDir, '../'))
 sys.path.append(repoDir)
 from main import main
+
+CALIBRATION_FIXTURE_DIR = os.path.join(
+    thisDir,
+    'opencap-test-data',
+    'Data',
+    'calibration-fixtures',
+)
+LABVALIDATION_CALIBRATION_VIDEOS = {
+    'Cam0': os.path.join(
+        CALIBRATION_FIXTURE_DIR,
+        'labvalidation',
+        'primary_success',
+        'labvalidation_subject5_session0_cam3_extrinsics.avi',
+    ),
+    'Cam1': os.path.join(
+        CALIBRATION_FIXTURE_DIR,
+        'labvalidation',
+        'e2e_calibration',
+        'labvalidation_subject5_session0_cam4_extrinsics.avi',
+    ),
+}
+LABVALIDATION_CALIBRATION_METADATA = """\
+checkerBoard:
+  black2BlackCornersHeight_n: 8
+  black2BlackCornersWidth_n: 11
+  placement: backWall
+  squareSideLength_mm: 60.0
+iphoneModel:
+  Cam0: iPhone13,3
+  Cam1: iPhone13,3
+"""
 
 # Helper functions to load and compare TRC and MOT files
 def load_trc(file, num_metadata_lines=5):
@@ -73,6 +106,57 @@ def compare_mot(output_mot_df, ref_mot_df, t0, tf):
             )
             rmse = calc_rmse(output_mot_df_slice[col], ref_mot_df_slice[col])
             assert rmse <= 0.5
+
+
+# uses 2 of 5 lab validation videos
+def test_main_calibration(tmp_path):
+    sessionName = 'labvalidation_calibration_2-cameras'
+    trialName = 'calibration'
+    trialID = 'calibration'
+    dataDir = tmp_path
+    sessionDir = os.path.join(dataDir, 'Data', sessionName)
+
+    os.makedirs(sessionDir, exist_ok=True)
+    with open(os.path.join(sessionDir, 'sessionMetadata.yaml'), 'w') as f:
+        f.write(LABVALIDATION_CALIBRATION_METADATA)
+
+    for camName, videoPath in LABVALIDATION_CALIBRATION_VIDEOS.items():
+        mediaDir = os.path.join(
+            sessionDir,
+            'Videos',
+            camName,
+            'InputMedia',
+            trialName,
+        )
+        os.makedirs(mediaDir, exist_ok=True)
+        shutil.copy2(
+            videoPath,
+            os.path.join(mediaDir, f'{trialID}.avi'),
+        )
+
+    main(
+        sessionName,
+        trialName,
+        trialID,
+        dataDir=dataDir,
+        genericFolderNames=True,
+        extrinsicsTrial=True,
+        imageUpsampleFactor=2,
+    )
+
+    for camName in LABVALIDATION_CALIBRATION_VIDEOS:
+        paramsPath = os.path.join(
+            sessionDir,
+            'Videos',
+            camName,
+            'cameraIntrinsicsExtrinsics.pickle',
+        )
+        assert os.path.exists(paramsPath)
+        with open(paramsPath, 'rb') as f:
+            cameraParams = pickle.load(f)
+        assert np.all(np.isfinite(cameraParams['rotation']))
+        assert np.all(np.isfinite(cameraParams['translation']))
+
 
 # End to end tests with different sync methods (hand, gait, general).
 # Also check that syncVer updates with main changes.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,17 +7,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-thisDir = os.path.dirname(os.path.realpath(__file__))
-repoDir = os.path.abspath(os.path.join(thisDir, '../'))
-sys.path.append(repoDir)
+from conftest import CALIBRATION_FIXTURE_DIR, REPO_DIR, TEST_DATA_ROOT
+
+sys.path.append(REPO_DIR)
 from main import main
 
-CALIBRATION_FIXTURE_DIR = os.path.join(
-    thisDir,
-    'opencap-test-data',
-    'Data',
-    'calibration-fixtures',
-)
 LABVALIDATION_CALIBRATION_VIDEOS = {
     'Cam0': os.path.join(
         CALIBRATION_FIXTURE_DIR,
@@ -172,7 +166,7 @@ def test_main(trialName, t0, tf, syncVer, caplog):
 
     sessionName = 'sync_2-cameras'
     trialID = trialName
-    dataDir = os.path.join(thisDir, 'opencap-test-data')
+    dataDir = TEST_DATA_ROOT
     main(
         sessionName,
         trialName,

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -19,6 +19,7 @@ from scipy.signal import sosfiltfilt, butter, find_peaks
 from scipy.interpolate import pchip_interpolate
 from scipy.spatial.transform import Rotation 
 from itertools import combinations
+from numpy.lib.stride_tricks import sliding_window_view
 import copy
 from utilsCameraPy3 import Camera, nview_linear_triangulations
 from utils import getOpenPoseMarkerNames, getOpenPoseFaceMarkers
@@ -273,6 +274,81 @@ def generate3Dgrid(CheckerBoardParams):
     
     return objectp3d
 
+# codex implementation of this https://github.com/opencv/opencv/issues/22083#issuecomment-2354470395
+# to identify where the black corner is on an asymmetrical chessboard
+def warpChessboardToCanonicalView(img, corners, pattern, squareResolution=1):
+    width, height = pattern[:2]
+    canonicalCorners = np.array([
+        [0.5, 0.5],
+        [width - 0.5, 0.5],
+        [width - 0.5, height - 0.5],
+        [0.5, height - 0.5]
+    ])
+    canonicalCorners = (canonicalCorners + 0.5) * squareResolution - 0.5
+
+    imageCorners = corners[[0,
+                            width - 1,
+                            (height - 1) * width + width - 1,
+                            (height - 1) * width]].reshape(-1, 2)
+    homography, _ = cv2.findHomography(imageCorners,
+                                       canonicalCorners.reshape(-1, 2))
+    if homography is None:
+        return None
+
+    return cv2.warpPerspective(
+        img,
+        homography,
+        ((width + 1) * squareResolution, (height + 1) * squareResolution),
+        flags=cv2.INTER_NEAREST)
+
+
+def needsCornerOrderFlip(canonicalImage, squareResolution=1):
+    if canonicalImage.ndim == 3:
+        normalizedImage = (canonicalImage / 255.0).mean(-1)
+    else:
+        normalizedImage = canonicalImage / 255.0
+
+    normalizedImage = sliding_window_view(
+        normalizedImage, (squareResolution, squareResolution)).mean((-1, -2))
+
+    def signOfDeterminant(i, j):
+        return np.sign(normalizedImage[i, j] * normalizedImage[i + 1, j + 1] -
+                       normalizedImage[i, j + 1] * normalizedImage[i + 1, j])
+
+    height, width = normalizedImage.shape[:2]
+    cornerSigns = (
+        signOfDeterminant(0, 0),
+        signOfDeterminant(0, width - 2),
+        signOfDeterminant(height - 2, width - 2),
+        signOfDeterminant(height - 2, 0))
+
+    if sum(cornerSigns) != 0:
+        return None, "Pattern not identified correctly, or not an asymmetric pattern"
+
+    return cornerSigns[0] > 0, None
+
+
+def ensureCornerOrdering(img, corners, pattern, squareResolution=1):
+    # Requires an asymmetric pattern, i.e. exactly one pattern dimension is odd.
+    if (pattern[0] % 2 == 0) == (pattern[1] % 2 == 0):
+        return corners, False, "Cannot ensure SB checkerboard ordering without an asymmetric pattern"
+
+    canonicalImage = warpChessboardToCanonicalView(
+        img, corners, pattern, squareResolution=squareResolution)
+    if canonicalImage is None:
+        return corners, False, "Could not compute checkerboard homography"
+
+    needsFlip, errorMessage = needsCornerOrderFlip(
+        canonicalImage, squareResolution=squareResolution)
+    if errorMessage is not None:
+        return corners, False, errorMessage
+
+    if needsFlip:
+        print('flipped corners for extrinsics')
+        corners = corners[::-1]
+
+    return corners, True, None
+
 # %%
 def saveCameraParameters(filename,CameraParams):
     if not os.path.exists(os.path.dirname(filename)):
@@ -429,19 +505,24 @@ def calcExtrinsics(imageFileName, CameraParams, CheckerBoardParams,
                 grayColor, CheckerBoardParams['dimensions'],  
                 cv2.CALIB_CB_ADAPTIVE_THRESH) 
 
-    # Fallback: if the standard detector fails, try the SB variant. EXHAUSTIVE
-    # recovers hard checkerboard views that the lighter SB path can miss.
+    # Fallback: if the standard detector fails, try the SB variant (more robust to
+    # certain lighting/contrast conditions where adaptive thresholding struggles).
+    # Using ACCURACY|LARGER without EXHAUSTIVE to keep the fallback reasonably fast.
     corners2_from_sb = False
     if not ret:
         ret_sb, corners_sb, _ = cv2.findChessboardCornersSBWithMeta(
             grayColor, CheckerBoardParams['dimensions'],
-            cv2.CALIB_CB_ACCURACY
-            | cv2.CALIB_CB_LARGER
-            | cv2.CALIB_CB_EXHAUSTIVE)
+                cv2.CALIB_CB_ACCURACY | cv2.CALIB_CB_LARGER | cv2.CALIB_CB_EXHAUSTIVE)
         if ret_sb:
             ret = True
-            corners = corners_sb
-            corners2_from_sb = True
+            corners, orderingSuccess, orderingError = ensureCornerOrdering(
+                grayColor, corners_sb, CheckerBoardParams['dimensions'],
+                squareResolution=2)
+            if orderingSuccess:
+                corners2_from_sb = True
+            else:
+                print('Rejected SB checkerboard detection: ' + orderingError)
+                ret = False
 
     # If desired number of corners can be detected then, 
     # refine the pixel coordinates and display 

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -429,14 +429,15 @@ def calcExtrinsics(imageFileName, CameraParams, CheckerBoardParams,
                 grayColor, CheckerBoardParams['dimensions'],  
                 cv2.CALIB_CB_ADAPTIVE_THRESH) 
 
-    # Fallback: if the standard detector fails, try the SB variant (more robust to
-    # certain lighting/contrast conditions where adaptive thresholding struggles).
-    # Using ACCURACY|LARGER without EXHAUSTIVE to keep the fallback reasonably fast.
+    # Fallback: if the standard detector fails, try the SB variant. EXHAUSTIVE
+    # recovers hard checkerboard views that the lighter SB path can miss.
     corners2_from_sb = False
     if not ret:
         ret_sb, corners_sb, _ = cv2.findChessboardCornersSBWithMeta(
             grayColor, CheckerBoardParams['dimensions'],
-            cv2.CALIB_CB_ACCURACY | cv2.CALIB_CB_LARGER)
+            cv2.CALIB_CB_ACCURACY
+            | cv2.CALIB_CB_LARGER
+            | cv2.CALIB_CB_EXHAUSTIVE)
         if ret_sb:
             ret = True
             corners = corners_sb

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -507,7 +507,8 @@ def calcExtrinsics(imageFileName, CameraParams, CheckerBoardParams,
 
     # Fallback: if the standard detector fails, try the SB variant (more robust to
     # certain lighting/contrast conditions where adaptive thresholding struggles).
-    # Using ACCURACY|LARGER without EXHAUSTIVE to keep the fallback reasonably fast.
+    # EXHAUSTIVE improves recovery on difficult boards without materially slowing
+    # typical calibration videos.
     corners2_from_sb = False
     if not ret:
         ret_sb, corners_sb, _ = cv2.findChessboardCornersSBWithMeta(


### PR DESCRIPTION
Added `cv2.CALIB_CB_EXHAUSTIVE` to the SB fallback path

Upon testing was finding that it was not significantly slower and in many cases was faster due to less upsampled retries. 

Compiled and tested lots of videos with the following results:
ACL are field videos where primary detector struggled, new fallback was better but still missing some, exhaustive was perfect

Comprehensive is my own set of calibrations with partial boards, distracting checkerboard-esque items to try and slow down exhaustive, etc

Utah set was passing with primary detector on my machine but not on others

| Dataset | Mode | Cases | Pass | Fail | Total Time |
|---|---:|---:|---:|---:|---:|
| ACL | Current | 18 | 13 | 5 | 22.294s |
| ACL | Exhaustive | 18 | 18 | 0 | 17.989s |
| Comprehensive | Current | 10 | 2 | 8 | 14.017s |
| Comprehensive | Exhaustive | 10 | 2 | 8 | 14.512s |
| LabValidation | Current | 90 | 90 | 0 | 31.144s |
| LabValidation | Exhaustive | 90 | 90 | 0 | 31.356s |
| Utah | Current | 4 | 4 | 0 | 1.606s |
| Utah | Exhaustive | 4 | 4 | 0 | 1.613s |
| **All** | **Current** | **122** | **109** | **13** | **69.061s** |
| **All** | **Exhaustive** | **122** | **114** | **8** | **65.470s** |

Worth noting everything that failed with exhaustive was intended to fail.

Even in cases with no board, partial board, and distracting items, the exhaustive change was on average less than .1 seconds slower per video. 

Included in PR is a new calibration testing file that runs through many of these trials and asserts correct behavior as well as low reprojection errors as well as a new more simple test in the main E2E testing file. Updated submodule to contain relevant videos